### PR TITLE
Use LivecodeResult for world, refactor world state

### DIFF
--- a/examples/foolish_guillemot/Cargo.toml
+++ b/examples/foolish_guillemot/Cargo.toml
@@ -16,7 +16,6 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4.42"
 console_error_panic_hook = "0.1"
-wee_alloc = "0.4"
 
 glam = "0.28.0"
 itertools = "0.10.5"

--- a/examples/foolish_guillemot/src/lib.rs
+++ b/examples/foolish_guillemot/src/lib.rs
@@ -135,7 +135,8 @@ impl MurreletModel {
     ) {
         let app_input =
             MurreletAppInput::new_no_key(vec2(dim_x, dim_y), vec2(mouse_x, mouse_y), click, frame);
-        self.livecode.update(&app_input, false);
+        // todo, show an error about this?
+        self.livecode.update(&app_input, false).ok();
     }
 
     // useful if you have shaders, this will list what canvases to draw to
@@ -188,7 +189,10 @@ impl WasmMurreletModelResult {
     }
 
     fn err(err: LivecodeErr) -> WasmMurreletModelResult {
-        WasmMurreletModelResult { m: None, err: err.to_string() }
+        WasmMurreletModelResult {
+            m: None,
+            err: err.to_string(),
+        }
     }
 
     #[wasm_bindgen]

--- a/examples/foolish_guillemot/src/lib.rs
+++ b/examples/foolish_guillemot/src/lib.rs
@@ -11,6 +11,7 @@ use murrelet_draw::{
     sequencers::*,
     style::{styleconf::*, MurreletPath},
 };
+use murrelet_livecode::livecode::LivecodeErr;
 use wasm_bindgen::prelude::*;
 
 #[cfg(feature = "wee_alloc")]
@@ -186,8 +187,8 @@ impl WasmMurreletModelResult {
         }
     }
 
-    fn err(err: String) -> WasmMurreletModelResult {
-        WasmMurreletModelResult { m: None, err }
+    fn err(err: LivecodeErr) -> WasmMurreletModelResult {
+        WasmMurreletModelResult { m: None, err: err.to_string() }
     }
 
     #[wasm_bindgen]

--- a/examples/foolish_guillemot/src/lib.rs
+++ b/examples/foolish_guillemot/src/lib.rs
@@ -11,7 +11,7 @@ use murrelet_draw::{
     sequencers::*,
     style::{styleconf::*, MurreletPath},
 };
-use murrelet_livecode::livecode::LivecodeErr;
+use murrelet_livecode::livecode::LivecodeError;
 use wasm_bindgen::prelude::*;
 
 #[cfg(feature = "wee_alloc")]
@@ -188,7 +188,7 @@ impl WasmMurreletModelResult {
         }
     }
 
-    fn err(err: LivecodeErr) -> WasmMurreletModelResult {
+    fn err(err: LivecodeError) -> WasmMurreletModelResult {
         WasmMurreletModelResult {
             m: None,
             err: err.to_string(),

--- a/examples/foolish_guillemot/src/lib.rs
+++ b/examples/foolish_guillemot/src/lib.rs
@@ -14,10 +14,6 @@ use murrelet_draw::{
 use murrelet_livecode::livecode::LivecodeError;
 use wasm_bindgen::prelude::*;
 
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 // from the wasm-rust tutorial, this let's you log messages to the js console
 // extern crate web_sys;
 

--- a/examples/murrelet_example/src/main.rs
+++ b/examples/murrelet_example/src/main.rs
@@ -81,7 +81,7 @@ impl Model {
 
         let app_input = MurreletAppInput::default_with_frames(self.curr_frame);
 
-        self.livecode.update(&app_input, true);
+        self.livecode.update(&app_input, true).ok();
 
         // this is also where you could update state
         // instead of having the model hold the config directly, you can have

--- a/murrelet_common/src/lib.rs
+++ b/murrelet_common/src/lib.rs
@@ -403,7 +403,6 @@ pub enum LivecodeValue {
 pub trait IsLivecodeSrc {
     fn update(&mut self, input: &LivecodeSrcUpdateInput);
     fn to_exec_funcs(&self) -> Vec<(String, LivecodeValue)>;
-    fn to_just_midi(&self) -> Vec<(String, LivecodeValue)>;
 }
 
 pub struct LivecodeSrc {
@@ -509,10 +508,6 @@ impl LivecodeSrc {
 
     pub fn to_world_vals(&self) -> Vec<(String, LivecodeValue)> {
         self.vs.iter().flat_map(|v| v.to_exec_funcs()).collect_vec()
-    }
-
-    pub fn to_timeless_vals(&self) -> Vec<(String, LivecodeValue)> {
-        self.vs.iter().flat_map(|v| v.to_just_midi()).collect_vec()
     }
 }
 

--- a/murrelet_livecode/src/app_src.rs
+++ b/murrelet_livecode/src/app_src.rs
@@ -146,19 +146,6 @@ impl IsLivecodeSrc for AppInputValues {
         self.result(has_click, cx, cy, mx, my, keys_cycle, keys_fired, w, h)
     }
 
-    fn to_just_midi(&self) -> Vec<(String, LivecodeValue)> {
-        let has_click = false;
-        let cx = 0.0;
-        let cy = 0.0;
-
-        let w = 100.0;
-        let h = 100.0;
-        let keys_cicle = [0; 26];
-        let keys_fired = [false; 26];
-
-        self.result(has_click, cx, cy, cx, cy, keys_cicle, keys_fired, w, h)
-    }
-
     fn update(&mut self, src_input: &LivecodeSrcUpdateInput) {
         let app = src_input.app();
 

--- a/murrelet_livecode/src/expr.rs
+++ b/murrelet_livecode/src/expr.rs
@@ -8,20 +8,11 @@ use murrelet_common::{clamp, ease, lerp, map_range, print_expect, smoothstep, Li
 use noise::{NoiseFn, Perlin};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
-use crate::livecode::{LiveCodeWorldState, TimelessLiveCodeWorldState};
+use crate::livecode::{LivecodeErr, TimelessLiveCodeWorldState};
 
-// livecode value to evalexpr value
-fn lc_val_to_expr(v: &LivecodeValue) -> Value {
-    match v {
-        LivecodeValue::Float(f) => Value::Float(*f),
-        LivecodeValue::Bool(f) => Value::Boolean(*f),
-        LivecodeValue::Int(f) => Value::Int(*f),
-    }
-}
 
-fn exec_funcs(livecode_src: Vec<(String, LivecodeValue)>) -> HashMapContext {
-    let mut ctx = context_map!{
-
+pub fn init_evalexpr_func_ctx() -> Result<HashMapContext, LivecodeErr> {
+    context_map!{
         // constants
         "PI" => Value::Float(PI.into()),
         "ROOT2" => Value::Float(2.0_f64.sqrt()),
@@ -157,59 +148,61 @@ fn exec_funcs(livecode_src: Vec<(String, LivecodeValue)>) -> HashMapContext {
             let len = vec2(x as f32, y as f32).length();
             Ok(Value::Float(len as f64))
         })
-    }.unwrap();
+    }.map_err(|err| {LivecodeErr::new(format!("error in init_evalexpr_func_ctx! {}", err))})
 
-    for (identifier, value) in &livecode_src {
-        // todo, maybe handle the result here to help dev
-        ctx.set_value(identifier.to_owned(), lc_val_to_expr(value))
-            .ok();
-    }
-    ctx
 }
 
 // sets defaults for the functions
-pub fn expr_context_no_world(m: &TimelessLiveCodeWorldState) -> HashMapContext {
+pub fn expr_context_no_world(ctx: &mut HashMapContext, m: &TimelessLiveCodeWorldState) -> Result<(), LivecodeErr> {
     let vals = m.to_timeless_vals();
-    exec_funcs(vals)
+    vals.update_ctx(ctx)?;
+    Ok(())
 }
 
-// this is used for the global state
-pub fn expr_context(w: &LiveCodeWorldState) -> HashMapContext {
-    let vals = w.to_world_vals();
 
-    let mut ctx = exec_funcs(vals);
-    // when we have a world state, we'll have the global ctx, so extend that
-    match w.ctx.eval_empty_with_context_mut(&mut ctx) {
-        Ok(_) => (),
-        Err(err) => println!("{:?}", err),
-    };
 
-    ctx
+
+// for (identifier, value) in &livecode_src {
+//     // todo, maybe handle the result here to help dev
+//     ctx.set_value(identifier.to_owned(), lc_val_to_expr(value))
+//         .ok();
+// }
+// ctx
+
+
+fn lc_val_to_expr(v: &LivecodeValue) -> Value {
+    match v {
+        LivecodeValue::Float(f) => Value::Float(*f),
+        LivecodeValue::Bool(f) => Value::Boolean(*f),
+        LivecodeValue::Int(f) => Value::Int(*f),
+    }
 }
 
 // simple mapping of values
 #[derive(Debug, Clone)]
-pub struct ExprWorldContextValues(Vec<(String, Value)>);
+pub struct ExprWorldContextValues(Vec<(String, LivecodeValue)>);
 impl ExprWorldContextValues {
-    pub fn new(v: Vec<(String, Value)>) -> Self {
+    pub fn new(v: Vec<(String, LivecodeValue)>) -> Self {
         Self(v)
     }
 
-    pub fn update_ctx(&self, ctx: &mut HashMapContext) {
+    pub fn update_ctx(&self, ctx: &mut HashMapContext) -> Result<(), LivecodeErr> {
         for (identifier, value) in &self.0 {
             // todo, maybe handle the result here to help dev
-            ctx.set_value(identifier.to_owned(), value.clone()).ok();
+            ctx.set_value(identifier.to_owned(), lc_val_to_expr(value)).map_err(|err|
+                LivecodeErr::new(format!("error setting value {}: {}", identifier, err)))?;
         }
+        Ok(())
     }
 
     pub fn update_ctx_with_prefix(&self, ctx: &mut HashMapContext, prefix: &str) {
         for (identifier, value) in &self.0 {
             let name = format!("{}{}", prefix, identifier);
-            add_variable_or_prefix_it(&name, value.clone(), ctx);
+            add_variable_or_prefix_it(&name, lc_val_to_expr(value), ctx);
         }
     }
 
-    pub fn set_val(&mut self, name: &str, val: Value) {
+    pub fn set_val(&mut self, name: &str, val: LivecodeValue) {
         self.0.push((name.to_owned(), val))
     }
 }
@@ -222,7 +215,7 @@ impl IntoExprWorldContext for Vec<(String, f32)> {
     fn as_expr_world_context_values(&self) -> ExprWorldContextValues {
         let v = self
             .iter()
-            .map(|(s, x)| (s.to_owned(), Value::Float(*x as f64)))
+            .map(|(s, x)| (s.to_owned(), LivecodeValue::Float(*x as f64)))
             .collect_vec();
         ExprWorldContextValues(v)
     }

--- a/murrelet_livecode/src/expr.rs
+++ b/murrelet_livecode/src/expr.rs
@@ -8,8 +8,7 @@ use murrelet_common::{clamp, ease, lerp, map_range, print_expect, smoothstep, Li
 use noise::{NoiseFn, Perlin};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
-use crate::livecode::{LivecodeErr, TimelessLiveCodeWorldState};
-
+use crate::livecode::LivecodeErr;
 
 pub fn init_evalexpr_func_ctx() -> Result<HashMapContext, LivecodeErr> {
     context_map!{
@@ -149,26 +148,7 @@ pub fn init_evalexpr_func_ctx() -> Result<HashMapContext, LivecodeErr> {
             Ok(Value::Float(len as f64))
         })
     }.map_err(|err| {LivecodeErr::new(format!("error in init_evalexpr_func_ctx! {}", err))})
-
 }
-
-// sets defaults for the functions
-pub fn expr_context_no_world(ctx: &mut HashMapContext, m: &TimelessLiveCodeWorldState) -> Result<(), LivecodeErr> {
-    let vals = m.to_timeless_vals();
-    vals.update_ctx(ctx)?;
-    Ok(())
-}
-
-
-
-
-// for (identifier, value) in &livecode_src {
-//     // todo, maybe handle the result here to help dev
-//     ctx.set_value(identifier.to_owned(), lc_val_to_expr(value))
-//         .ok();
-// }
-// ctx
-
 
 fn lc_val_to_expr(v: &LivecodeValue) -> Value {
     match v {
@@ -189,8 +169,10 @@ impl ExprWorldContextValues {
     pub fn update_ctx(&self, ctx: &mut HashMapContext) -> Result<(), LivecodeErr> {
         for (identifier, value) in &self.0 {
             // todo, maybe handle the result here to help dev
-            ctx.set_value(identifier.to_owned(), lc_val_to_expr(value)).map_err(|err|
-                LivecodeErr::new(format!("error setting value {}: {}", identifier, err)))?;
+            ctx.set_value(identifier.to_owned(), lc_val_to_expr(value))
+                .map_err(|err| {
+                    LivecodeErr::new(format!("error setting value {}: {}", identifier, err))
+                })?;
         }
         Ok(())
     }

--- a/murrelet_livecode/src/expr.rs
+++ b/murrelet_livecode/src/expr.rs
@@ -8,9 +8,9 @@ use murrelet_common::{clamp, ease, lerp, map_range, print_expect, smoothstep, Li
 use noise::{NoiseFn, Perlin};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
-use crate::livecode::LivecodeErr;
+use crate::livecode::{LivecodeError, LivecodeResult};
 
-pub fn init_evalexpr_func_ctx() -> Result<HashMapContext, LivecodeErr> {
+pub fn init_evalexpr_func_ctx() -> LivecodeResult<HashMapContext> {
     context_map!{
         // constants
         "PI" => Value::Float(PI.into()),
@@ -147,7 +147,7 @@ pub fn init_evalexpr_func_ctx() -> Result<HashMapContext, LivecodeErr> {
             let len = vec2(x as f32, y as f32).length();
             Ok(Value::Float(len as f64))
         })
-    }.map_err(|err| {LivecodeErr::new(format!("error in init_evalexpr_func_ctx! {}", err))})
+    }.map_err(|err| {LivecodeError::EvalExpr(format!("error in init_evalexpr_func_ctx!"), err)})
 }
 
 fn lc_val_to_expr(v: &LivecodeValue) -> Value {
@@ -166,12 +166,12 @@ impl ExprWorldContextValues {
         Self(v)
     }
 
-    pub fn update_ctx(&self, ctx: &mut HashMapContext) -> Result<(), LivecodeErr> {
+    pub fn update_ctx(&self, ctx: &mut HashMapContext) -> LivecodeResult<()> {
         for (identifier, value) in &self.0 {
             // todo, maybe handle the result here to help dev
             ctx.set_value(identifier.to_owned(), lc_val_to_expr(value))
                 .map_err(|err| {
-                    LivecodeErr::new(format!("error setting value {}: {}", identifier, err))
+                    LivecodeError::EvalExpr(format!("error setting value {}", identifier), err)
                 })?;
         }
         Ok(())

--- a/murrelet_livecode/src/lib.rs
+++ b/murrelet_livecode/src/lib.rs
@@ -3,4 +3,5 @@ pub mod boop;
 pub mod expr;
 pub mod livecode;
 pub mod nestedit;
+pub mod state;
 pub mod unitcells;

--- a/murrelet_livecode/src/livecode.rs
+++ b/murrelet_livecode/src/livecode.rs
@@ -1,29 +1,20 @@
 #![allow(dead_code)]
 use evalexpr::build_operator_tree;
 use evalexpr::EvalexprError;
-use evalexpr::HashMapContext;
 use evalexpr::Node;
 use glam::vec2;
 use glam::vec3;
 use glam::Vec2;
 use glam::Vec3;
 use murrelet_common::clamp;
-use murrelet_common::ease;
-use murrelet_common::map_range;
 
-use murrelet_common::IsLivecodeSrc;
-use murrelet_common::LivecodeSrc;
-use murrelet_common::LivecodeValue;
 use murrelet_common::MurreletColor;
-use murrelet_common::MurreletTime;
 use serde::Deserialize;
 
-use crate::expr::ExprWorldContextValues;
+use crate::state::LivecodeWorldState;
 use crate::unitcells::LazyNodeF32;
 use crate::unitcells::LazyNodeF32Def;
-use crate::unitcells::{
-    EvaluableUnitCell, UnitCellControlExprBool, UnitCellControlExprF32, UnitCellWorldState,
-};
+use crate::unitcells::{EvaluableUnitCell, UnitCellControlExprBool, UnitCellControlExprF32};
 
 // for default values
 pub fn empty_vec<T>() -> Vec<T> {
@@ -51,23 +42,23 @@ pub type LivecodeResult<T> = Result<T, LivecodeError>;
 
 // 'world is approximately one frame
 pub trait LivecodeFromWorld<T> {
-    fn o(&self, w: &LiveCodeWorldState) -> LivecodeResult<T>;
+    fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<T>;
 }
 
 impl LivecodeFromWorld<Vec2> for [ControlF32; 2] {
-    fn o(&self, w: &LiveCodeWorldState) -> LivecodeResult<Vec2> {
+    fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<Vec2> {
         Ok(vec2(self[0].o(w)?, self[1].o(w)?))
     }
 }
 
 impl LivecodeFromWorld<Vec3> for [ControlF32; 3] {
-    fn o(&self, w: &LiveCodeWorldState) -> LivecodeResult<Vec3> {
+    fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<Vec3> {
         Ok(vec3(self[0].o(w)?, self[1].o(w)?, self[2].o(w)?))
     }
 }
 
 impl LivecodeFromWorld<MurreletColor> for [ControlF32; 4] {
-    fn o(&self, w: &LiveCodeWorldState) -> LivecodeResult<MurreletColor> {
+    fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<MurreletColor> {
         // by default, clamp saturation and value
         Ok(MurreletColor::hsva(
             self[0].o(w)?,
@@ -215,9 +206,8 @@ impl ControlF32 {
         }
     }
 
-    pub fn o(&self, w: &LiveCodeWorldState) -> LivecodeResult<f32> {
-        let world_context = UnitCellWorldState::from_world(w);
-        self.to_unitcell_control().eval(&world_context)
+    pub fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<f32> {
+        self.to_unitcell_control().eval(&w)
     }
 }
 
@@ -249,9 +239,8 @@ impl ControlBool {
         }
     }
 
-    pub fn o(&self, w: &LiveCodeWorldState) -> LivecodeResult<bool> {
-        let world_context = UnitCellWorldState::from_world(w);
-        self.to_unitcell_control().eval(&world_context)
+    pub fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<bool> {
+        self.to_unitcell_control().eval(w)
     }
 
     pub fn default(&self) -> bool {
@@ -261,420 +250,5 @@ impl ControlBool {
             ControlBool::Float(x) => *x > 0.0,
             ControlBool::Expr(_) => false, // eh
         }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct LiveCodeWorldState {
-    // Usually time is available, except the one moment where we're loading the config needed to generate
-    // the timing config, which is needed to generate the time. That _should_ all be internal,
-    time: Option<LiveCodeTimeInstantInfo>,
-    cached_context: HashMapContext,
-}
-impl LiveCodeWorldState {
-    pub fn clone_ctx_and_add_world(
-        evalexpr_func_ctx: &HashMapContext,
-        livecode_src: &LivecodeSrc,
-        maybe_time: Option<LiveCodeTimeInstantInfo>,
-        maybe_node: Option<Node>,
-    ) -> LivecodeResult<HashMapContext> {
-        let mut ctx = evalexpr_func_ctx.clone();
-
-        let mut w = livecode_src.to_world_vals();
-        if let Some(time) = maybe_time {
-            w.extend(time.to_exec_funcs());
-        }
-        // add the world to the ctx
-        let vals = ExprWorldContextValues::new(w);
-        vals.update_ctx(&mut ctx)?;
-
-        // add the node to the context
-        if let Some(node) = maybe_node {
-            node.eval_empty_with_context_mut(&mut ctx)
-                .map_err(|err| LivecodeError::EvalExpr("node eval failed".to_owned(), err))?;
-        }
-
-        Ok(ctx)
-    }
-
-    pub fn new<'a>(
-        evalexpr_func_ctx: &HashMapContext,
-        livecode_src: &LivecodeSrc,
-        time: LiveCodeTimeInstantInfo,
-        node: Node,
-    ) -> LivecodeResult<LiveCodeWorldState> {
-        let cached_context =
-            Self::clone_ctx_and_add_world(evalexpr_func_ctx, livecode_src, Some(time), Some(node))?;
-
-        Ok(LiveCodeWorldState {
-            time: Some(time),
-            cached_context,
-        })
-    }
-
-    pub fn new_timeless(
-        evalexpr_func_ctx: &HashMapContext,
-        livecode_src: &LivecodeSrc,
-    ) -> LivecodeResult<LiveCodeWorldState> {
-        let cached_context =
-            Self::clone_ctx_and_add_world(evalexpr_func_ctx, livecode_src, None, None)?;
-
-        Ok(LiveCodeWorldState {
-            time: None,
-            cached_context,
-        })
-    }
-
-    // this should use the cached one if it exists, or return an error
-    pub(crate) fn ctx(&self) -> &HashMapContext {
-        &self.cached_context
-    }
-
-    pub fn time(&self) -> LiveCodeTimeInstantInfo {
-        // basically always world should have time, except when computing
-        // the time component.
-        self.time.expect("tried calling time on timeless world")
-    }
-
-    pub fn actual_frame(&self) -> f32 {
-        self.time().actual_frame()
-    }
-
-    pub fn actual_frame_u64(&self) -> u64 {
-        self.time().actual_frame_u64()
-    }
-
-    pub fn should_debug(&self) -> bool {
-        self.time().seconds_since_updated_realtime() < 0.1
-    }
-
-    pub fn is_on_bar(&self) -> bool {
-        self.time().is_on_bar()
-    }
-
-    pub(crate) fn ctx_mut(&mut self) -> &mut HashMapContext {
-        &mut self.cached_context
-    }
-}
-
-#[derive(Copy, Clone, Debug)]
-pub struct LivecodeTimingConfig {
-    pub bpm: f32,
-    pub fps: f32,
-    pub realtime: bool,
-    pub beats_per_bar: f32,
-}
-impl LivecodeTimingConfig {
-    fn seconds_from_config(&self, system_timing: LiveCodeTiming) -> f32 {
-        if self.realtime {
-            self.current_time_seconds_realtime(system_timing)
-        } else {
-            self.current_time_seconds_frame(system_timing)
-        }
-    }
-
-    fn beat_from_config(&self, system_timing: LiveCodeTiming) -> f32 {
-        //time_from_config(self.bpm, self.realtime, actual_frame, self.fps, system_timing.start)
-        let seconds = self.seconds_from_config(system_timing);
-        self.seconds_to_beats(seconds)
-    }
-
-    fn seconds_to_beats(&self, s: f32) -> f32 {
-        let minutes = s / 60.0;
-        minutes * self.bpm
-    }
-
-    fn beats_to_bar(&self, beats: f32) -> f32 {
-        beats / self.beats_per_bar
-    }
-
-    fn seconds_to_bar(&self, s: f32) -> f32 {
-        self.beats_to_bar(self.seconds_to_beats(s))
-    }
-
-    fn current_time_seconds_realtime(&self, system_timing: LiveCodeTiming) -> f32 {
-        (MurreletTime::now() - system_timing.start).as_secs_f32()
-    }
-
-    fn current_time_seconds_frame(&self, system_timing: LiveCodeTiming) -> f32 {
-        system_timing.frame as f32 / self.fps
-    }
-}
-
-#[derive(Copy, Clone, Debug)]
-pub struct LiveCodeTimeInstantInfo {
-    timing_config: LivecodeTimingConfig,
-    system_timing: LiveCodeTiming,
-}
-impl LiveCodeTimeInstantInfo {
-    pub fn new(
-        timing_config: LivecodeTimingConfig,
-        system_timing: LiveCodeTiming,
-    ) -> LiveCodeTimeInstantInfo {
-        LiveCodeTimeInstantInfo {
-            timing_config,
-            system_timing,
-        }
-    }
-
-    pub fn debug(&self) -> String {
-        format!(
-            "realtime: {}\nseconds: {:.01}\nbeat: {:.01}\nbar: {:.01} ({})\nframe: {}\nlast updated {:?}",
-            self.timing_config.realtime,
-            self.seconds(),
-            self.beat(),
-            self.bar(),
-            self.is_on_bar(),
-            self.actual_frame(),
-            self.system_timing.last_config_update
-        )
-    }
-
-    pub fn actual_frame_u64(&self) -> u64 {
-        self.system_timing.frame
-    }
-
-    pub fn actual_frame(&self) -> f32 {
-        self.system_timing.frame as f32
-    }
-
-    // magical
-    pub fn beat(&self) -> f32 {
-        self.timing_config.beat_from_config(self.system_timing)
-    }
-
-    pub fn bar(&self) -> f32 {
-        self.beat() / self.timing_config.beats_per_bar
-    }
-
-    pub fn seconds(&self) -> f32 {
-        self.timing_config.seconds_from_config(self.system_timing)
-    }
-
-    pub fn is_on_bar(&self) -> bool {
-        // okay so, we want to know the prev beat.
-        let prev_time = if self.timing_config.realtime {
-            let render_time = self.system_timing.last_render_time;
-            render_time.as_secs_f32()
-        } else {
-            let prev_frame = self.system_timing.frame - 1;
-            prev_frame as f32 / self.timing_config.fps
-        };
-
-        // check if this beat rounds differently than the curr one
-        let prev_beat = self.timing_config.seconds_to_beats(prev_time);
-
-        let curr_beat_bar = self.bar().floor();
-        let prev_beat_bar = (prev_beat / self.timing_config.beats_per_bar).floor();
-
-        curr_beat_bar as i32 > prev_beat_bar as i32
-    }
-
-    pub fn seconds_since_updated_realtime(&self) -> f32 {
-        // check when last updated
-        let last_update_time = self.system_timing.last_config_update;
-        // check how much time has passed since it was last updated
-        let time = MurreletTime::now() - last_update_time;
-        time.as_secs_f32()
-    }
-
-    fn seconds_since_updated_frame(&self) -> f32 {
-        // check when last updated
-        let last_update_time = self.system_timing.last_config_update_frame;
-        // check how much time has passed since it was last updated
-        let frames_since_updated = self.system_timing.frame - last_update_time;
-
-        (frames_since_updated as f32) / self.timing_config.fps
-    }
-
-    pub fn seconds_between_render_times(&self) -> f32 {
-        if self.timing_config.realtime {
-            (self.system_timing.last_render_time - self.system_timing.prev_render_time)
-                .as_secs_f32()
-        } else {
-            1.0 / self.timing_config.fps
-        }
-    }
-
-    pub fn seconds_since_reload(&self) -> f32 {
-        if self.timing_config.realtime {
-            self.seconds_since_updated_realtime()
-        } else {
-            self.seconds_since_updated_frame()
-        }
-    }
-
-    fn bars_since_reload(&self) -> f32 {
-        let sec_since_updated = self.seconds_since_reload();
-
-        // and convert to bars
-        self.timing_config.seconds_to_bar(sec_since_updated)
-    }
-
-    fn beat_scaled_offset(&self, mult: f32, offset: f32) -> f32 {
-        (self.beat() * mult) + offset
-    }
-
-    fn beat_scaled_fract(&self, mult: f32) -> f32 {
-        self.beat_scaled(mult).fract()
-    }
-
-    fn beat_scaled_idx(&self, mult: f32, count: usize) -> usize {
-        self.beat_scaled(mult).floor() as usize % count
-    }
-
-    fn beat_scaled(&self, mult: f32) -> f32 {
-        self.beat_scaled_offset(mult, 0.0)
-    }
-
-    fn beat_scaled_ramp_min_max(&self, mult: f32, min: f32, max: f32) -> f32 {
-        map_range(self.beat_scaled_fract(mult), 0.0, 1.0, min, max)
-    }
-
-    fn beat_scaled_min_max(&self, mult: f32, min: f32, max: f32) -> f32 {
-        map_range(self.beat_scaled(mult), 0.0, 1.0, min, max)
-    }
-}
-
-impl IsLivecodeSrc for LiveCodeTimeInstantInfo {
-    fn update(&mut self, input: &murrelet_common::LivecodeSrcUpdateInput) {
-        self.system_timing.frame = input.app().elapsed_frames();
-    }
-
-    fn to_exec_funcs(&self) -> Vec<(String, LivecodeValue)> {
-        let time = self.beat();
-        let frame = self.actual_frame_u64();
-
-        vec![
-            ("t".to_owned(), LivecodeValue::Float(time as f64)),
-            (
-                "tease".to_owned(),
-                LivecodeValue::Float(ease(time.into(), 0.2, 0.0)),
-            ),
-            (
-                "stease".to_owned(),
-                LivecodeValue::Float(ease(time.into(), 0.01, 0.0)),
-            ),
-            ("ti".to_owned(), LivecodeValue::Int(time as i64)),
-            ("f".to_owned(), LivecodeValue::Float(frame as f64)),
-            ("fi".to_owned(), LivecodeValue::Int(frame as i64)),
-        ]
-    }
-
-    fn to_just_midi(&self) -> Vec<(String, LivecodeValue)> {
-        let time = self.beat();
-        let frame = self.actual_frame_u64();
-
-        vec![
-            ("t".to_owned(), LivecodeValue::Float(time as f64)),
-            (
-                "tease".to_owned(),
-                LivecodeValue::Float(ease(time.into(), 0.2, 0.0)),
-            ),
-            (
-                "stease".to_owned(),
-                LivecodeValue::Float(ease(time.into(), 0.01, 0.0)),
-            ),
-            ("ti".to_owned(), LivecodeValue::Int(time as i64)),
-            ("f".to_owned(), LivecodeValue::Float(frame as f64)),
-            ("fi".to_owned(), LivecodeValue::Int(frame as i64)),
-        ]
-    }
-}
-
-pub struct LiveCodeConfigInfo {
-    pub config_next_check: MurreletTime,
-    updated: bool,
-}
-
-impl Default for LiveCodeConfigInfo {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl LiveCodeConfigInfo {
-    pub fn new() -> LiveCodeConfigInfo {
-        LiveCodeConfigInfo {
-            config_next_check: MurreletTime::in_one_sec(),
-            updated: true,
-        }
-    }
-
-    pub fn should_check(&self) -> bool {
-        MurreletTime::now() > self.config_next_check
-    }
-
-    pub fn reset(&mut self) {
-        self.updated = false;
-    }
-
-    pub fn update(&mut self, updated: bool, config_next_check: MurreletTime) {
-        self.updated = updated;
-        self.config_next_check = config_next_check;
-    }
-
-    pub fn updated(&self) -> bool {
-        self.updated
-    }
-}
-
-#[derive(Copy, Clone, Debug)]
-pub struct LiveCodeTiming {
-    start: MurreletTime,
-    frame: u64,
-    start_frame: u64,
-    true_start: MurreletTime,         // not updated when reset
-    last_config_update: MurreletTime, // i don't know, config could also have it
-    last_config_update_frame: u64,
-    last_render_time: MurreletTime, // used for realtime bar update, also to measure time between frames for simulations
-    prev_render_time: MurreletTime, // used for simulations
-}
-
-impl Default for LiveCodeTiming {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl LiveCodeTiming {
-    pub fn new() -> LiveCodeTiming {
-        LiveCodeTiming {
-            start: MurreletTime::now(),
-            frame: 0,
-            start_frame: 0,
-            true_start: MurreletTime::now(),
-            last_config_update: MurreletTime::now(),
-            last_config_update_frame: 0,
-            last_render_time: MurreletTime::now(),
-            prev_render_time: MurreletTime::now(),
-        }
-    }
-
-    pub fn frame(&self) -> u64 {
-        self.frame
-    }
-
-    pub fn true_start(&self) -> MurreletTime {
-        self.true_start
-    }
-
-    pub fn config_updated(&mut self) {
-        self.last_config_update = MurreletTime::now();
-        self.last_config_update_frame = self.frame; // copy over curr frame
-    }
-
-    pub fn reset_time(&mut self) {
-        self.start = MurreletTime::now();
-        self.start_frame = self.frame;
-    }
-
-    pub fn set_last_render_time(&mut self) {
-        self.prev_render_time = self.last_render_time;
-        self.last_render_time = MurreletTime::now();
-    }
-
-    pub fn set_frame(&mut self, frame: u64) {
-        self.frame = frame - self.start_frame;
     }
 }

--- a/murrelet_livecode/src/livecode.rs
+++ b/murrelet_livecode/src/livecode.rs
@@ -40,7 +40,6 @@ impl std::error::Error for LivecodeError {}
 
 pub type LivecodeResult<T> = Result<T, LivecodeError>;
 
-// 'world is approximately one frame
 pub trait LivecodeFromWorld<T> {
     fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<T>;
 }

--- a/murrelet_livecode/src/livecode.rs
+++ b/murrelet_livecode/src/livecode.rs
@@ -218,69 +218,6 @@ impl ControlF32 {
         let world_context = UnitCellEvalContext::from_world(w)?;
         self.to_unitcell_control().eval(&world_context)
     }
-
-    // pub fn o(&self, w: &LiveCodeWorldState) -> f32 {
-
-    // match self._o(w) {
-    //     Ok(x) => x,
-    //     Err(err) => {
-    //         println!("{}", err);
-    //         1.0
-    //     }
-    // }
-    // }
-
-    // pub fn vec3(c: &[ControlF32; 3], w: &LiveCodeWorldState) -> Vec3 {
-    //     vec3(c[0].o(w), c[1].o(w), c[2].o(w))
-    // }
-
-    // pub fn array3(c: &[ControlF32; 3], w: &LiveCodeWorldState) -> [f32; 3] {
-    //     [c[0].o(w), c[1].o(w), c[2].o(w)]
-    // }
-
-    // pub fn array4(c: &[ControlF32; 4], w: &LiveCodeWorldState) -> [f32; 4] {
-    //     [c[0].o(w), c[1].o(w), c[2].o(w), c[3].o(w)]
-    // }
-
-    // pub fn hsva(c: &[ControlF32; 4], w: &LiveCodeWorldState) -> MurreletColor {
-    //     let c = ControlF32::array4(c, w);
-    //     // gonna clamp saturation and value
-    //     hsva(c[0], clamp(c[1], 0.0, 1.0), clamp(c[2], 0.0, 1.0), c[3]).into_lin_srgba()
-    // }
-
-    // pub fn hsva_unclamped(c: &[ControlF32; 4], w: &LiveCodeWorldState) -> MurreletColor {
-    //     let c = ControlF32::array4(c, w);
-    //     // gonna clamp just value
-    //     hsva(c[0], c[1], c[2], c[3]).into_lin_srgba()
-    // }
-
-    // pub fn hsva_more_info(c: &[ControlF32; 4], w: &LiveCodeWorldState) -> [f32; 4] {
-    //     let (r, g, b, a) = ControlF32::hsva(c, w).into_components();
-    //     [r, g, b, a]
-    // }
-
-    // pub fn vec2_midi(c: &[ControlF32; 2], w: &TimelessLiveCodeWorldState) -> Vec2 {
-    //     vec2(c[0].just_midi(w), c[1].just_midi(w))
-    // }
-
-    // pub fn vec3_midi(c: &[ControlF32; 3], w: &TimelessLiveCodeWorldState) -> Vec3 {
-    //     vec3(c[0].just_midi(w), c[1].just_midi(w), c[2].just_midi(w))
-    // }
-
-    // pub fn array3_midi(c: &[ControlF32; 3], w: &TimelessLiveCodeWorldState) -> [f32; 3] {
-    //     [c[0].just_midi(w), c[1].just_midi(w), c[2].just_midi(w)]
-    // }
-
-    // pub fn hsva_midi(c: &[ControlF32; 4], w: &TimelessLiveCodeWorldState) -> MurreletColor {
-    //     let c = ControlF32::array4_midi(c, w);
-    //     // gonna clamp saturation and value
-    //     hsva(c[0], clamp(c[1], 0.0, 1.0), clamp(c[2], 0.0, 1.0), c[3]).into_lin_srgba()
-    // }
-
-    // pub fn hsva_more_info_midi(c: &[ControlF32; 4], w: &TimelessLiveCodeWorldState) -> [f32; 4] {
-    //     let (r, g, b, a) = ControlF32::hsva_midi(c, w).into_components();
-    //     [r, g, b, a]
-    // }
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -313,15 +250,7 @@ impl ControlBool {
 
     pub fn o(&self, w: &LiveCodeWorldState) -> LivecodeResult<bool> {
         let world_context = UnitCellEvalContext::from_world(w)?;
-
         self.to_unitcell_control().eval(&world_context)
-        // match self.to_unitcell_control().eval(&world_context) {
-        //     Ok(x) => x,
-        //     Err(err) => {
-        //         println!("{}", err);
-        //         false
-        //     }
-        // }
     }
 
     pub fn default(&self) -> bool {
@@ -339,7 +268,6 @@ pub struct LiveCodeWorldState<'a> {
     // Usually time is available, except the one moment where we're loading the config needed to generate
     // the timing config, which is needed to generate the time. That _should_ all be internal,
     time: Option<LiveCodeTimeInstantInfo>,
-    // pub ctx: Node, // this is the global ctx
     cached_context: HashMapContext,
 }
 impl<'a> LiveCodeWorldState<'a> {
@@ -349,11 +277,9 @@ impl<'a> LiveCodeWorldState<'a> {
         time: LiveCodeTimeInstantInfo,
         ctx: Node,
     ) -> LivecodeResult<LiveCodeWorldState<'a>> {
-        // set up the cached_hm
         let mut w = LiveCodeWorldState {
             livecode_src,
             time: Some(time),
-            // ctx,
             cached_context: evalexpr_func_ctx,
         };
 
@@ -456,17 +382,6 @@ impl LivecodeTimingConfig {
 
     fn current_time_seconds_frame(&self, system_timing: LiveCodeTiming) -> f32 {
         system_timing.frame as f32 / self.fps
-    }
-}
-
-impl Default for LivecodeTimingConfig {
-    fn default() -> Self {
-        Self {
-            bpm: 135.0,
-            fps: 30.0,
-            realtime: false,
-            beats_per_bar: 4.0,
-        }
     }
 }
 
@@ -655,8 +570,6 @@ pub struct LiveCodeConfigInfo {
     pub config_next_check: MurreletTime,
     updated: bool,
 }
-
-// LoadableDrawConfig::load_if_needed(self.config_next_check)
 
 impl Default for LiveCodeConfigInfo {
     fn default() -> Self {

--- a/murrelet_livecode/src/state.rs
+++ b/murrelet_livecode/src/state.rs
@@ -1,0 +1,442 @@
+use evalexpr::{HashMapContext, Node};
+use murrelet_common::*;
+
+use crate::{
+    expr::{ExprWorldContextValues, IntoExprWorldContext},
+    livecode::{LivecodeError, LivecodeResult},
+    unitcells::{MixedEvalDefs, UnitCellContext},
+};
+
+#[derive(Debug, Clone)]
+enum LivecodeWorldStateStage {
+    Timeless,
+    World(LiveCodeTimeInstantInfo),
+    Unit(LiveCodeTimeInstantInfo),
+    Lazy(LiveCodeTimeInstantInfo),
+}
+impl LivecodeWorldStateStage {
+    fn add_step(&self, stage: LivecodeWorldStateStage) -> LivecodeWorldStateStage {
+        // todo, i could start to represent the tree of steps.. but right now, just do the last one
+        stage
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LivecodeWorldState {
+    context: HashMapContext,
+    stage: LivecodeWorldStateStage,
+}
+impl LivecodeWorldState {
+    fn clone_ctx_and_add_world(
+        evalexpr_func_ctx: &HashMapContext,
+        livecode_src: &LivecodeSrc,
+        maybe_time: Option<LiveCodeTimeInstantInfo>,
+        maybe_node: Option<Node>,
+    ) -> LivecodeResult<HashMapContext> {
+        let mut ctx = evalexpr_func_ctx.clone();
+
+        let mut w = livecode_src.to_world_vals();
+        if let Some(time) = maybe_time {
+            w.extend(time.to_exec_funcs());
+        }
+        // add the world to the ctx
+        let vals = ExprWorldContextValues::new(w);
+        vals.update_ctx(&mut ctx)?;
+
+        // add the node to the context
+        if let Some(node) = maybe_node {
+            node.eval_empty_with_context_mut(&mut ctx)
+                .map_err(|err| LivecodeError::EvalExpr("node eval failed".to_owned(), err))?;
+        }
+
+        Ok(ctx)
+    }
+
+    pub fn new<'a>(
+        evalexpr_func_ctx: &HashMapContext,
+        livecode_src: &LivecodeSrc,
+        time: LiveCodeTimeInstantInfo,
+        node: Node,
+    ) -> LivecodeResult<LivecodeWorldState> {
+        let context =
+            Self::clone_ctx_and_add_world(evalexpr_func_ctx, livecode_src, Some(time), Some(node))?;
+
+        Ok(LivecodeWorldState {
+            context,
+            stage: LivecodeWorldStateStage::World(time),
+        })
+    }
+
+    pub fn new_timeless(
+        evalexpr_func_ctx: &HashMapContext,
+        livecode_src: &LivecodeSrc,
+    ) -> LivecodeResult<LivecodeWorldState> {
+        let context = Self::clone_ctx_and_add_world(evalexpr_func_ctx, livecode_src, None, None)?;
+
+        Ok(LivecodeWorldState {
+            context,
+            stage: LivecodeWorldStateStage::Timeless,
+        })
+    }
+
+    // this should use the cached one if it exists, or return an error
+    pub(crate) fn ctx(&self) -> &HashMapContext {
+        &self.context
+    }
+
+    pub fn time(&self) -> LiveCodeTimeInstantInfo {
+        // basically always world should have time, except when computing
+        // the time component.
+        match self.stage {
+            LivecodeWorldStateStage::Timeless => panic!("checking time in a timeless world"),
+            LivecodeWorldStateStage::World(t) => t,
+            LivecodeWorldStateStage::Unit(t) => t,
+            LivecodeWorldStateStage::Lazy(t) => t,
+        }
+    }
+
+    pub fn actual_frame(&self) -> f32 {
+        self.time().actual_frame()
+    }
+
+    pub fn actual_frame_u64(&self) -> u64 {
+        self.time().actual_frame_u64()
+    }
+
+    pub fn should_debug(&self) -> bool {
+        self.time().seconds_since_updated_realtime() < 0.1
+    }
+
+    pub fn is_on_bar(&self) -> bool {
+        self.time().is_on_bar()
+    }
+
+    pub(crate) fn ctx_mut(&mut self) -> &mut HashMapContext {
+        &mut self.context
+    }
+
+    pub fn update_with_defs(&mut self, more_defs: &MixedEvalDefs) -> LivecodeResult<()> {
+        more_defs.update_ctx(&mut self.ctx_mut())
+    }
+
+    pub fn clone_to_unitcell(
+        &self,
+        unit_cell_ctx: &UnitCellContext,
+        prefix: &str,
+    ) -> LivecodeResult<LivecodeWorldState> {
+        let mut context = self.context.clone();
+        unit_cell_ctx
+            .as_expr_world_context_values()
+            .update_ctx_with_prefix(&mut context, prefix);
+
+        let r = LivecodeWorldState {
+            context,
+            stage: self
+                .stage
+                .add_step(LivecodeWorldStateStage::Unit(self.time())),
+        };
+
+        Ok(r)
+
+        // LivecodeWorldState::World(_, ctx) => {
+
+        // }
+        // LivecodeWorldState::Unit(..) => {
+        //     unreachable!("tried initializing an already initialized cell")
+        // }
+        // LivecodeWorldState::Lazy(..) => unreachable!("tried initializing an lazy cell"),
+    }
+
+    pub fn clone_to_lazy(&self) -> Self {
+        let context = self.context.clone();
+        LivecodeWorldState {
+            context,
+            stage: self
+                .stage
+                .add_step(LivecodeWorldStateStage::Lazy(self.time())),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct LivecodeTimingConfig {
+    pub bpm: f32,
+    pub fps: f32,
+    pub realtime: bool,
+    pub beats_per_bar: f32,
+}
+impl LivecodeTimingConfig {
+    fn seconds_from_config(&self, system_timing: LiveCodeTiming) -> f32 {
+        if self.realtime {
+            self.current_time_seconds_realtime(system_timing)
+        } else {
+            self.current_time_seconds_frame(system_timing)
+        }
+    }
+
+    fn beat_from_config(&self, system_timing: LiveCodeTiming) -> f32 {
+        //time_from_config(self.bpm, self.realtime, actual_frame, self.fps, system_timing.start)
+        let seconds = self.seconds_from_config(system_timing);
+        self.seconds_to_beats(seconds)
+    }
+
+    fn seconds_to_beats(&self, s: f32) -> f32 {
+        let minutes = s / 60.0;
+        minutes * self.bpm
+    }
+
+    fn current_time_seconds_realtime(&self, system_timing: LiveCodeTiming) -> f32 {
+        (MurreletTime::now() - system_timing.start).as_secs_f32()
+    }
+
+    fn current_time_seconds_frame(&self, system_timing: LiveCodeTiming) -> f32 {
+        system_timing.frame as f32 / self.fps
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct LiveCodeTimeInstantInfo {
+    timing_config: LivecodeTimingConfig,
+    system_timing: LiveCodeTiming,
+}
+impl LiveCodeTimeInstantInfo {
+    pub fn new(
+        timing_config: LivecodeTimingConfig,
+        system_timing: LiveCodeTiming,
+    ) -> LiveCodeTimeInstantInfo {
+        LiveCodeTimeInstantInfo {
+            timing_config,
+            system_timing,
+        }
+    }
+
+    pub fn debug(&self) -> String {
+        format!(
+            "realtime: {}\nseconds: {:.01}\nbeat: {:.01}\nbar: {:.01} ({})\nframe: {}\nlast updated {:?}",
+            self.timing_config.realtime,
+            self.seconds(),
+            self.beat(),
+            self.bar(),
+            self.is_on_bar(),
+            self.actual_frame(),
+            self.system_timing.last_config_update
+        )
+    }
+
+    pub fn actual_frame_u64(&self) -> u64 {
+        self.system_timing.frame
+    }
+
+    pub fn actual_frame(&self) -> f32 {
+        self.system_timing.frame as f32
+    }
+
+    // magical
+    pub fn beat(&self) -> f32 {
+        self.timing_config.beat_from_config(self.system_timing)
+    }
+
+    pub fn bar(&self) -> f32 {
+        self.beat() / self.timing_config.beats_per_bar
+    }
+
+    pub fn seconds(&self) -> f32 {
+        self.timing_config.seconds_from_config(self.system_timing)
+    }
+
+    pub fn is_on_bar(&self) -> bool {
+        // okay so, we want to know the prev beat.
+        let prev_time = if self.timing_config.realtime {
+            let render_time = self.system_timing.last_render_time;
+            render_time.as_secs_f32()
+        } else {
+            let prev_frame = self.system_timing.frame - 1;
+            prev_frame as f32 / self.timing_config.fps
+        };
+
+        // check if this beat rounds differently than the curr one
+        let prev_beat = self.timing_config.seconds_to_beats(prev_time);
+
+        let curr_beat_bar = self.bar().floor();
+        let prev_beat_bar = (prev_beat / self.timing_config.beats_per_bar).floor();
+
+        curr_beat_bar as i32 > prev_beat_bar as i32
+    }
+
+    pub fn seconds_since_updated_realtime(&self) -> f32 {
+        // check when last updated
+        let last_update_time = self.system_timing.last_config_update;
+        // check how much time has passed since it was last updated
+        let time = MurreletTime::now() - last_update_time;
+        time.as_secs_f32()
+    }
+
+    fn seconds_since_updated_frame(&self) -> f32 {
+        // check when last updated
+        let last_update_time = self.system_timing.last_config_update_frame;
+        // check how much time has passed since it was last updated
+        let frames_since_updated = self.system_timing.frame - last_update_time;
+
+        (frames_since_updated as f32) / self.timing_config.fps
+    }
+
+    pub fn seconds_between_render_times(&self) -> f32 {
+        if self.timing_config.realtime {
+            (self.system_timing.last_render_time - self.system_timing.prev_render_time)
+                .as_secs_f32()
+        } else {
+            1.0 / self.timing_config.fps
+        }
+    }
+
+    pub fn seconds_since_reload(&self) -> f32 {
+        if self.timing_config.realtime {
+            self.seconds_since_updated_realtime()
+        } else {
+            self.seconds_since_updated_frame()
+        }
+    }
+}
+
+impl IsLivecodeSrc for LiveCodeTimeInstantInfo {
+    fn update(&mut self, input: &murrelet_common::LivecodeSrcUpdateInput) {
+        self.system_timing.frame = input.app().elapsed_frames();
+    }
+
+    fn to_exec_funcs(&self) -> Vec<(String, LivecodeValue)> {
+        let time = self.beat();
+        let frame = self.actual_frame_u64();
+
+        vec![
+            ("t".to_owned(), LivecodeValue::Float(time as f64)),
+            (
+                "tease".to_owned(),
+                LivecodeValue::Float(ease(time.into(), 0.2, 0.0)),
+            ),
+            (
+                "stease".to_owned(),
+                LivecodeValue::Float(ease(time.into(), 0.01, 0.0)),
+            ),
+            ("ti".to_owned(), LivecodeValue::Int(time as i64)),
+            ("f".to_owned(), LivecodeValue::Float(frame as f64)),
+            ("fi".to_owned(), LivecodeValue::Int(frame as i64)),
+        ]
+    }
+
+    fn to_just_midi(&self) -> Vec<(String, LivecodeValue)> {
+        let time = self.beat();
+        let frame = self.actual_frame_u64();
+
+        vec![
+            ("t".to_owned(), LivecodeValue::Float(time as f64)),
+            (
+                "tease".to_owned(),
+                LivecodeValue::Float(ease(time.into(), 0.2, 0.0)),
+            ),
+            (
+                "stease".to_owned(),
+                LivecodeValue::Float(ease(time.into(), 0.01, 0.0)),
+            ),
+            ("ti".to_owned(), LivecodeValue::Int(time as i64)),
+            ("f".to_owned(), LivecodeValue::Float(frame as f64)),
+            ("fi".to_owned(), LivecodeValue::Int(frame as i64)),
+        ]
+    }
+}
+
+pub struct LiveCodeConfigInfo {
+    pub config_next_check: MurreletTime,
+    updated: bool,
+}
+
+impl Default for LiveCodeConfigInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LiveCodeConfigInfo {
+    pub fn new() -> LiveCodeConfigInfo {
+        LiveCodeConfigInfo {
+            config_next_check: MurreletTime::in_one_sec(),
+            updated: true,
+        }
+    }
+
+    pub fn should_check(&self) -> bool {
+        MurreletTime::now() > self.config_next_check
+    }
+
+    pub fn reset(&mut self) {
+        self.updated = false;
+    }
+
+    pub fn update(&mut self, updated: bool, config_next_check: MurreletTime) {
+        self.updated = updated;
+        self.config_next_check = config_next_check;
+    }
+
+    pub fn updated(&self) -> bool {
+        self.updated
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct LiveCodeTiming {
+    start: MurreletTime,
+    frame: u64,
+    start_frame: u64,
+    true_start: MurreletTime,         // not updated when reset
+    last_config_update: MurreletTime, // i don't know, config could also have it
+    last_config_update_frame: u64,
+    last_render_time: MurreletTime, // used for realtime bar update, also to measure time between frames for simulations
+    prev_render_time: MurreletTime, // used for simulations
+}
+
+impl Default for LiveCodeTiming {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LiveCodeTiming {
+    pub fn new() -> LiveCodeTiming {
+        LiveCodeTiming {
+            start: MurreletTime::now(),
+            frame: 0,
+            start_frame: 0,
+            true_start: MurreletTime::now(),
+            last_config_update: MurreletTime::now(),
+            last_config_update_frame: 0,
+            last_render_time: MurreletTime::now(),
+            prev_render_time: MurreletTime::now(),
+        }
+    }
+
+    pub fn frame(&self) -> u64 {
+        self.frame
+    }
+
+    pub fn true_start(&self) -> MurreletTime {
+        self.true_start
+    }
+
+    pub fn config_updated(&mut self) {
+        self.last_config_update = MurreletTime::now();
+        self.last_config_update_frame = self.frame; // copy over curr frame
+    }
+
+    pub fn reset_time(&mut self) {
+        self.start = MurreletTime::now();
+        self.start_frame = self.frame;
+    }
+
+    pub fn set_last_render_time(&mut self) {
+        self.prev_render_time = self.last_render_time;
+        self.last_render_time = MurreletTime::now();
+    }
+
+    pub fn set_frame(&mut self, frame: u64) {
+        self.frame = frame - self.start_frame;
+    }
+}

--- a/murrelet_livecode/src/state.rs
+++ b/murrelet_livecode/src/state.rs
@@ -16,7 +16,7 @@ enum LivecodeWorldStateStage {
 }
 impl LivecodeWorldStateStage {
     fn add_step(&self, stage: LivecodeWorldStateStage) -> LivecodeWorldStateStage {
-        // todo, i could start to represent the tree of steps.. but right now, just do the last one
+        // todo, i could start to represent the tree of steps.. but right now, just do the latest one
         stage
     }
 }
@@ -137,14 +137,6 @@ impl LivecodeWorldState {
         };
 
         Ok(r)
-
-        // LivecodeWorldState::World(_, ctx) => {
-
-        // }
-        // LivecodeWorldState::Unit(..) => {
-        //     unreachable!("tried initializing an already initialized cell")
-        // }
-        // LivecodeWorldState::Lazy(..) => unreachable!("tried initializing an lazy cell"),
     }
 
     pub fn clone_to_lazy(&self) -> Self {
@@ -175,7 +167,6 @@ impl LivecodeTimingConfig {
     }
 
     fn beat_from_config(&self, system_timing: LiveCodeTiming) -> f32 {
-        //time_from_config(self.bpm, self.realtime, actual_frame, self.fps, system_timing.start)
         let seconds = self.seconds_from_config(system_timing);
         self.seconds_to_beats(seconds)
     }
@@ -311,27 +302,11 @@ impl IsLivecodeSrc for LiveCodeTimeInstantInfo {
             ("t".to_owned(), LivecodeValue::Float(time as f64)),
             (
                 "tease".to_owned(),
-                LivecodeValue::Float(ease(time.into(), 0.2, 0.0)),
-            ),
-            (
-                "stease".to_owned(),
-                LivecodeValue::Float(ease(time.into(), 0.01, 0.0)),
-            ),
-            ("ti".to_owned(), LivecodeValue::Int(time as i64)),
-            ("f".to_owned(), LivecodeValue::Float(frame as f64)),
-            ("fi".to_owned(), LivecodeValue::Int(frame as i64)),
-        ]
-    }
-
-    fn to_just_midi(&self) -> Vec<(String, LivecodeValue)> {
-        let time = self.beat();
-        let frame = self.actual_frame_u64();
-
-        vec![
-            ("t".to_owned(), LivecodeValue::Float(time as f64)),
-            (
-                "tease".to_owned(),
-                LivecodeValue::Float(ease(time.into(), 0.2, 0.0)),
+                LivecodeValue::Float(ease(
+                    time.into(),
+                    (1.0 / self.timing_config.beats_per_bar).into(),
+                    0.0,
+                )),
             ),
             (
                 "stease".to_owned(),

--- a/murrelet_livecode/src/unitcells.rs
+++ b/murrelet_livecode/src/unitcells.rs
@@ -130,16 +130,6 @@ fn create_unit_cell<'a>(
 
     // great, now we have it built. return it!
     Ok(world_state)
-
-    // let mut unit_cell_world_ctx = world_state.ctx().clone();
-
-    // // now update the unit_cell context to have the node
-    // if let Some(node) = maybe_node {
-    //     node.eval_raw(&mut unit_cell_world_ctx)?;
-    // }
-
-    // // great, now we have it built. return it!
-    // Ok(unit_cell_world_ctx)
 }
 
 impl<CtxSource, Target> TmpUnitCells<CtxSource, Target>
@@ -570,13 +560,6 @@ impl LazyNodeF32 {
             world: world.clone_to_lazy(),
         })
     }
-
-    // fn new_from_livecode(n: Node, w: &LiveCodeWorldState) -> Self {
-    //     Self::Node(LazyNodeF32Inner {
-    //         n,
-    //         world: LivecodeWorldState::from_world(w).into_lazy(),
-    //     })
-    // }
 
     pub fn n(&self) -> Option<&Node> {
         match self {

--- a/murrelet_livecode/src/unitcells.rs
+++ b/murrelet_livecode/src/unitcells.rs
@@ -173,13 +173,6 @@ where
             &self.ctx,
             w.should_debug(),
         )))
-        // match maybe_world_context {
-        //     Ok(world_context) => Ok(UnitCells::new(self.eval_with_ctx(&world_context, &self.ctx, w.should_debug()))),
-        //     Err(err) => {
-        //         println!("{}", err);
-        //         UnitCells::new(vec![])
-        //     }
-        // }
     }
 }
 
@@ -441,7 +434,6 @@ impl LazyNodeF32Def {
 impl LivecodeFromWorld<LazyNodeF32> for LazyNodeF32Def {
     fn o(&self, w: &LiveCodeWorldState) -> LivecodeResult<LazyNodeF32> {
         let world_context = UnitCellEvalContext::from_world(w)?;
-        // let world_context = print_expect(maybe_world_context, "error in world ctx").unwrap();
         Ok(LazyNodeF32::new(self.0.clone(), world_context.ctx))
     }
 }
@@ -579,7 +571,7 @@ pub struct UnitCellEvalContext<'a> {
 impl<'a> UnitCellEvalContext<'a> {
     pub fn from_world(w: &'a LiveCodeWorldState<'a>) -> LivecodeResult<UnitCellEvalContext<'a>> {
         Ok(UnitCellEvalContext {
-            ctx: w.ctx()?.clone(), //expr_context(w),
+            ctx: w.ctx()?.clone(),
             w: Some(w),
         })
     }

--- a/murrelet_livecode_macros/murrelet_livecode_derive/examples/tests.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/examples/tests.rs
@@ -30,9 +30,6 @@ struct SequencerTest {
 
 fn main() {}
 
-
-
-
 fn make_grid(
     x: usize,
     y: usize,
@@ -58,8 +55,7 @@ fn make_grid(
                     }
 
                     let offset_angle = AnglePi::new(1.0 / 6.0);
-                    let diag_scale =
-                        offset_angle.to_norm_dir() * cell_size.x / (100.0 * 0.5);
+                    let diag_scale = offset_angle.to_norm_dir() * cell_size.x / (100.0 * 0.5);
 
                     center *= diag_scale;
                     center

--- a/murrelet_livecode_macros/murrelet_livecode_derive/examples/tests.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/examples/tests.rs
@@ -1,21 +1,92 @@
-// use glam::*;
-// use murrelet_common::MurreletColor;
-// use murrelet_livecode_derive::{Boop, Livecode, NestEdit, UnitCell};
+use glam::*;
+use murrelet_common::*;
+use murrelet_livecode::unitcells::*;
+use murrelet_livecode_derive::{Livecode, UnitCell};
 
-// #[derive(Clone, Boop, NestEdit)]
-// struct SomethingElse {
-//     a_number: f32,
-//     b_color: MurreletColor,
-//     c_vec2: Vec2,
-// }
+#[derive(Debug, Clone, Livecode, UnitCell, Default)]
+struct SomethingElse {
+    a_number: f32,
+    b_color: MurreletColor,
+    c_vec2: Vec2,
+}
 
-// #[derive(Clone, Boop, NestEdit)]
-// enum Something {
-//     A,
-//     B(SomethingElse),
-// }
+#[derive(Debug, Clone, Livecode, UnitCell, Default)]
+enum EnumTest {
+    #[default]
+    A,
+    B(SomethingElse),
+}
 
-// #[derive(Clone, Boop, NestEdit)]
-// struct TestNewType(Vec<Something>);
+#[derive(Debug, Clone, Livecode, UnitCell, Default)]
+struct TestNewType(Vec<EnumTest>);
+
+#[derive(Debug, Clone, Livecode)]
+struct SequencerTest {
+    sequencer: SimpleSquareSequence,
+    ctx: UnitCellCtx,
+    #[livecode(src = "sequencer", ctx = "ctx")]
+    node: UnitCells<TestNewType>,
+}
 
 fn main() {}
+
+
+
+
+fn make_grid(
+    x: usize,
+    y: usize,
+    cell_size: Vec2,
+    offset_alternating: bool,
+) -> Vec<UnitCellContext> {
+    let x_usize = x;
+    let y_usize = y;
+
+    (0..x_usize)
+        .flat_map(|x| {
+            let x_idx = IdxInRange::new(x, x_usize);
+            (0..y_usize).map(move |y| {
+                let y_idx = IdxInRange::new(y, y_usize);
+                let idx = IdxInRange2d::new_from_idx(x_idx, y_idx);
+                let ctx = UnitCellExprWorldContext::from_idx2d(idx, 1.0);
+
+                let mut center = if offset_alternating {
+                    let mut center = idx.to_alternating_i().center_of_cell();
+                    center += vec2(-0.5, 0.0);
+                    if idx.i.i() % 2 == 1 {
+                        center += vec2(0.5, 0.5);
+                    }
+
+                    let offset_angle = AnglePi::new(1.0 / 6.0);
+                    let diag_scale =
+                        offset_angle.to_norm_dir() * cell_size.x / (100.0 * 0.5);
+
+                    center *= diag_scale;
+                    center
+                } else {
+                    let mut center = idx.center_of_cell();
+                    center *= vec2(cell_size.x, cell_size.y) / 100.0;
+                    center
+                };
+
+                center *= 100.0;
+
+                let transform = Mat3::from_translation(center)
+                    * Mat3::from_scale(cell_size.x / 100.0 * Vec2::ONE);
+                UnitCellContext::new(ctx, mat4_from_mat3_transform(transform))
+            })
+        })
+        .collect::<Vec<_>>()
+}
+
+#[derive(Clone, Debug, Default, Livecode, UnitCell)]
+pub struct SimpleSquareSequence {
+    rows: usize,
+    cols: usize,
+    size: f32,
+}
+impl UnitCellCreator for SimpleSquareSequence {
+    fn to_unit_cell_ctxs(&self) -> Vec<UnitCellContext> {
+        make_grid(self.cols, self.rows, vec2(self.size, self.size), false)
+    }
+}

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_livecode.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_livecode.rs
@@ -470,12 +470,13 @@ impl GenFinal for FieldTokensLivecode {
 
         let for_world = {
             quote! {#name: {
+                let ctx = murrelet_livecode::unitcells::UnitCellWorldState::from_world(w);
                 murrelet_livecode::unitcells::TmpUnitCells::new(
                     self.#target.o(w)?,
                     Box::new(self.#name.clone()),
                     #maybe_more_ctx,
                     #prefix
-                ).o(w)?
+                ).o(&ctx)?
             }}
         };
 

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_livecode.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_livecode.rs
@@ -110,7 +110,7 @@ impl GenFinal for FieldTokensLivecode {
             }
 
             impl murrelet_livecode::livecode::LivecodeFromWorld<#name> for #new_ident {
-                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
+                fn o(&self, w: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     Ok(#name {
                         #(#for_world,)*
                     })
@@ -149,7 +149,7 @@ impl GenFinal for FieldTokensLivecode {
                 #(#for_struct,)*
             }
             impl murrelet_livecode::livecode::LivecodeFromWorld<#name> for #new_ident {
-                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
+                fn o(&self, w: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     match self {
                         #(#for_world,)*
                     }
@@ -183,7 +183,7 @@ impl GenFinal for FieldTokensLivecode {
             #vis struct #new_ident(#(#for_struct,)*);
 
             impl murrelet_livecode::livecode::LivecodeFromWorld<#name> for #new_ident {
-                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
+                fn o(&self, w: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     Ok(#name(#(#for_world,)*))
                 }
             }
@@ -470,13 +470,12 @@ impl GenFinal for FieldTokensLivecode {
 
         let for_world = {
             quote! {#name: {
-                let ctx = murrelet_livecode::unitcells::UnitCellWorldState::from_world(w);
                 murrelet_livecode::unitcells::TmpUnitCells::new(
                     self.#target.o(w)?,
                     Box::new(self.#name.clone()),
                     #maybe_more_ctx,
                     #prefix
-                ).o(&ctx)?
+                ).o(&w)?
             }}
         };
 

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_livecode.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_livecode.rs
@@ -71,38 +71,6 @@ impl LivecodeFieldType {
         }
     }
 
-    pub(crate) fn for_timeless_world(&self, idents: StructIdents) -> TokenStream2 {
-        let name = idents.name();
-        let orig_ty = idents.orig_ty();
-
-        match self.0 {
-            //ControlType::F32_2 => quote! {#name: self.#name.just_midi(m) },
-            //ControlType::F32_3 => quote! {#name: self.#name.just_midi(m) },
-            //ControlType::LinSrgba => quote! {#name:self.#name.just_midi(m) },
-            ControlType::ColorUnclamped => {
-                quote! {#name: murrelet_livecode::livecode::ControlF32::hsva_unclamped_midi(&self.#name, m)?}
-            }
-            _ => quote! {#name: self.#name.just_midi(m)? as #orig_ty},
-        }
-    }
-
-    pub(crate) fn for_timeless_newtype_world(&self, idents: StructIdents) -> TokenStream2 {
-        let orig_ty = idents.orig_ty();
-        match self.0 {
-            // ControlType::F32_2 => quote! {murrelet_livecode::livecode::ControlF32::vec2_midi(&self.0, m)},
-            // ControlType::F32_3 => quote! {murrelet_livecode::livecode::ControlF32::vec3_midi(&self.0, m)},
-            // ControlType::LinSrgba => quote! {murrelet_livecode::livecode::ControlF32::hsva_midi(&self.0, m)},
-            ControlType::F32_2 => quote! { self.0.just_midi(&m)? },
-            ControlType::F32_3 => quote! { self.0.just_midi(&m)? },
-            ControlType::Color => quote! { self.0.just_midi(&m)? },
-            ControlType::LazyNodeF32 => quote! { self.0.just_midi(&w)? },
-            ControlType::ColorUnclamped => {
-                quote! {murrelet_livecode::livecode::ControlF32::hsva_unclamped_midi(&self.0, m)?}
-            }
-            _ => quote! {self.0.just_midi(m)? as #orig_ty},
-        }
-    }
-
     pub(crate) fn for_control(&self, idents: StructIdents) -> TokenStream2 {
         let name = idents.name();
         quote! { #name: self.#name.to_control() }
@@ -120,7 +88,6 @@ impl LivecodeFieldType {
 pub(crate) struct FieldTokensLivecode {
     pub(crate) for_struct: TokenStream2,
     pub(crate) for_world: TokenStream2,
-    pub(crate) for_timeless_world: TokenStream2,
     pub(crate) for_to_control: TokenStream2, // a way to convert from original to control
 }
 impl GenFinal for FieldTokensLivecode {
@@ -134,7 +101,6 @@ impl GenFinal for FieldTokensLivecode {
 
         let for_struct = variants.iter().map(|x| x.for_struct.clone());
         let for_world = variants.iter().map(|x| x.for_world.clone());
-        let for_timeless_world = variants.iter().map(|x| x.for_timeless_world.clone());
         let for_to_control = variants.iter().map(|x| x.for_to_control.clone());
 
         quote! {
@@ -147,12 +113,6 @@ impl GenFinal for FieldTokensLivecode {
                 fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
                     Ok(#name {
                         #(#for_world,)*
-                    })
-                }
-
-                fn just_midi(&self, m: &murrelet_livecode::livecode::TimelessLiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
-                    Ok(#name {
-                        #(#for_timeless_world,)*
                     })
                 }
             }
@@ -177,7 +137,6 @@ impl GenFinal for FieldTokensLivecode {
 
         let for_struct = variants.iter().map(|x| x.for_struct.clone());
         let for_world = variants.iter().map(|x| x.for_world.clone());
-        let for_timeless_world = variants.iter().map(|x| x.for_timeless_world.clone());
         let for_to_control = variants.iter().map(|x| x.for_to_control.clone());
 
         let enum_tag = idents.tags;
@@ -193,12 +152,6 @@ impl GenFinal for FieldTokensLivecode {
                 fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
                     match self {
                         #(#for_world,)*
-                    }
-                }
-
-                fn just_midi(&self, m: &murrelet_livecode::livecode::TimelessLiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
-                    match self {
-                        #(#for_timeless_world,)*
                     }
                 }
             }
@@ -223,7 +176,6 @@ impl GenFinal for FieldTokensLivecode {
 
         let for_struct = variants.iter().map(|x| x.for_struct.clone());
         let for_world = variants.iter().map(|x| x.for_world.clone());
-        let for_timeless_world = variants.iter().map(|x| x.for_timeless_world.clone());
         let for_to_control = variants.iter().map(|x| x.for_to_control.clone());
 
         quote! {
@@ -233,10 +185,6 @@ impl GenFinal for FieldTokensLivecode {
             impl murrelet_livecode::livecode::LivecodeFromWorld<#name> for #new_ident {
                 fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
                     Ok(#name(#(#for_world,)*))
-                }
-
-                fn just_midi(&self, m: &murrelet_livecode::livecode::TimelessLiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
-                    Ok(#name(#(#for_timeless_world,)*))
                 }
             }
 
@@ -264,15 +212,12 @@ impl GenFinal for FieldTokensLivecode {
         };
         let for_world = LivecodeFieldType(ctrl).for_newtype_world(idents.clone());
 
-        let for_timeless_world = LivecodeFieldType(ctrl).for_timeless_newtype_world(idents.clone());
-
         let for_to_control =
             LivecodeFieldType(ctrl).for_newtype_control(idents.clone(), parent_ident.clone());
 
         FieldTokensLivecode {
             for_struct,
             for_world,
-            for_timeless_world,
             for_to_control,
         }
     }
@@ -298,11 +243,8 @@ impl GenFinal for FieldTokensLivecode {
         };
 
         // for world
-        let for_world = quote! { #new_ident::#variant_ident(s) => Ok(#name::#variant_ident(s.o(w)?)) };
-
-        // for timeless world
-        let for_timeless_world =
-            quote! { #new_ident::#variant_ident(s) => Ok(#name::#variant_ident(s.just_midi(m)?)) };
+        let for_world =
+            quote! { #new_ident::#variant_ident(s) => Ok(#name::#variant_ident(s.o(w)?)) };
 
         let for_to_control =
             quote! { #name::#variant_ident(s) => #new_ident::#variant_ident(s.to_control()) };
@@ -310,7 +252,6 @@ impl GenFinal for FieldTokensLivecode {
         FieldTokensLivecode {
             for_struct,
             for_world,
-            for_timeless_world,
             for_to_control,
         }
     }
@@ -327,7 +268,6 @@ impl GenFinal for FieldTokensLivecode {
         let for_world: TokenStream2 = {
             quote! { #new_ident::#variant_ident => Ok(#name::#variant_ident) }
         };
-        let for_timeless_world = for_world.clone();
         let for_to_control = {
             quote! { #name::#variant_ident => #new_ident::#variant_ident }
         };
@@ -335,7 +275,6 @@ impl GenFinal for FieldTokensLivecode {
         FieldTokensLivecode {
             for_struct,
             for_world,
-            for_timeless_world,
             for_to_control,
         }
     }
@@ -351,13 +290,11 @@ impl GenFinal for FieldTokensLivecode {
         let for_world: TokenStream2 = {
             quote! {#name: self.#name.clone()}
         };
-        let for_timeless_world = for_world.clone();
         let for_to_control = quote! {#name: self.#name.clone()};
 
         FieldTokensLivecode {
             for_struct,
             for_world,
-            for_timeless_world,
             for_to_control,
         }
     }
@@ -374,14 +311,11 @@ impl GenFinal for FieldTokensLivecode {
         };
         let for_world = LivecodeFieldType(ctrl).for_world(idents.clone());
 
-        let for_timeless_world = LivecodeFieldType(ctrl).for_timeless_world(idents.clone());
-
         let for_to_control = LivecodeFieldType(ctrl).for_control(idents.clone());
 
         FieldTokensLivecode {
             for_struct,
             for_world,
-            for_timeless_world,
             for_to_control,
         }
     }
@@ -430,13 +364,6 @@ impl GenFinal for FieldTokensLivecode {
                 quote! {#name: self.#name.clone()}
             }
         };
-        let for_timeless_world = {
-            if should_o {
-                quote! {#name: self.#name.iter().map(|x| x.just_midi(m)).collect::<Result<Vec<_>, _>>()?}
-            } else {
-                quote! {#name: self.#name.clone()}
-            }
-        };
 
         let for_to_control = {
             if should_o {
@@ -449,7 +376,6 @@ impl GenFinal for FieldTokensLivecode {
         FieldTokensLivecode {
             for_struct,
             for_world,
-            for_timeless_world,
             for_to_control,
         }
     }
@@ -472,9 +398,6 @@ impl GenFinal for FieldTokensLivecode {
         let for_world = {
             quote! {#name: self.#name.o(w)?}
         };
-        let for_timeless_world = {
-            quote! {#name: self.#name.just_midi(m)?}
-        };
         let for_to_control = {
             quote! {#name: self.#name.to_control()}
         };
@@ -482,7 +405,6 @@ impl GenFinal for FieldTokensLivecode {
         FieldTokensLivecode {
             for_struct,
             for_world,
-            for_timeless_world,
             for_to_control,
         }
     }
@@ -556,16 +478,6 @@ impl GenFinal for FieldTokensLivecode {
                 ).o(w)?
             }}
         };
-        let for_timeless_world = {
-            quote! {#name: {
-                murrelet_livecode::unitcells::TmpUnitCells::new(
-                    self.#target.just_midi(m)?,
-                    Box::new(self.#name.clone()),
-                    #maybe_more_ctx,
-                    #prefix
-                ).just_midi(m)?
-            }}
-        };
 
         let for_to_control = {
             quote! {#name: {
@@ -579,7 +491,6 @@ impl GenFinal for FieldTokensLivecode {
         FieldTokensLivecode {
             for_struct,
             for_world,
-            for_timeless_world,
             for_to_control,
         }
     }
@@ -628,13 +539,6 @@ impl GenFinal for FieldTokensLivecode {
                 quote! {self.0.clone()}
             }
         };
-        let for_timeless_world = {
-            if should_o {
-                quote! {self.0.iter().map(|x| x.just_midi(m)).collect::<Result<Vec<_>, _>>()?}
-            } else {
-                quote! {self.0.clone()}
-            }
-        };
 
         let for_to_control = {
             if should_o {
@@ -647,7 +551,6 @@ impl GenFinal for FieldTokensLivecode {
         FieldTokensLivecode {
             for_struct,
             for_world,
-            for_timeless_world,
             for_to_control,
         }
     }

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_livecode.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_livecode.rs
@@ -110,7 +110,7 @@ impl GenFinal for FieldTokensLivecode {
             }
 
             impl murrelet_livecode::livecode::LivecodeFromWorld<#name> for #new_ident {
-                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
+                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     Ok(#name {
                         #(#for_world,)*
                     })
@@ -149,7 +149,7 @@ impl GenFinal for FieldTokensLivecode {
                 #(#for_struct,)*
             }
             impl murrelet_livecode::livecode::LivecodeFromWorld<#name> for #new_ident {
-                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
+                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     match self {
                         #(#for_world,)*
                     }
@@ -183,7 +183,7 @@ impl GenFinal for FieldTokensLivecode {
             #vis struct #new_ident(#(#for_struct,)*);
 
             impl murrelet_livecode::livecode::LivecodeFromWorld<#name> for #new_ident {
-                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
+                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     Ok(#name(#(#for_world,)*))
                 }
             }

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_livecode.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_livecode.rs
@@ -28,20 +28,20 @@ impl LivecodeFieldType {
         let name = idents.name();
         let orig_ty = idents.orig_ty();
         match self.0 {
-            ControlType::F32_2 => quote! {#name: self.#name.o(w)},
-            ControlType::F32_3 => quote! {#name: self.#name.o(w)},
-            ControlType::Color => quote! {#name: self.#name.o(w)},
+            ControlType::F32_2 => quote! {#name: self.#name.o(w)?},
+            ControlType::F32_3 => quote! {#name: self.#name.o(w)?},
+            ControlType::Color => quote! {#name: self.#name.o(w)?},
             ControlType::ColorUnclamped => {
-                quote! {#name: murrelet_livecode::livecode::ControlF32::hsva_unclamped(&self.#name, w)}
+                quote! {#name: murrelet_livecode::livecode::ControlF32::hsva_unclamped(&self.#name, w)?}
             }
-            ControlType::LazyNodeF32 => quote! {#name: self.#name.o(w)},
+            ControlType::LazyNodeF32 => quote! {#name: self.#name.o(w)?},
             _ => {
                 let f32_out = match (idents.data.f32min, idents.data.f32max) {
-                    (None, None) => quote! {self.#name.o(w)},
-                    (None, Some(max)) => quote! {f32::min(self.#name.o(w), #max)},
-                    (Some(min), None) => quote! {f32::max(#min, self.#name.o(w))},
+                    (None, None) => quote! {self.#name.o(w)?},
+                    (None, Some(max)) => quote! {f32::min(self.#name.o(w)?, #max)},
+                    (Some(min), None) => quote! {f32::max(#min, self.#name.o(w)?)},
                     (Some(min), Some(max)) => {
-                        quote! {f32::min(f32::max(#min, self.#name.o(w)), #max)}
+                        quote! {f32::min(f32::max(#min, self.#name.o(w)?), #max)}
                     }
                 };
                 quote! {#name: #f32_out as #orig_ty}
@@ -52,19 +52,19 @@ impl LivecodeFieldType {
     pub(crate) fn for_newtype_world(&self, idents: StructIdents) -> TokenStream2 {
         let orig_ty = idents.orig_ty();
         match self.0 {
-            ControlType::F32_2 => quote! { self.0.o(&w) },
-            ControlType::F32_3 => quote! { self.0.o(&w) },
-            ControlType::Color => quote! { self.0.o(&w) },
-            ControlType::LazyNodeF32 => quote! { self.0.o(&w) },
+            ControlType::F32_2 => quote! { self.0.o(&w)? },
+            ControlType::F32_3 => quote! { self.0.o(&w)? },
+            ControlType::Color => quote! { self.0.o(&w)? },
+            ControlType::LazyNodeF32 => quote! { self.0.o(&w)? },
             ControlType::ColorUnclamped => {
-                quote! {murrelet_livecode::livecode::ControlF32::hsva_unclamped(&self.0, w)}
+                quote! {murrelet_livecode::livecode::ControlF32::hsva_unclamped(&self.0, w)?}
             }
             _ => {
                 let f32_out = match (idents.data.f32min, idents.data.f32max) {
-                    (None, None) => quote! {self.0.o(w)},
-                    (None, Some(max)) => quote! {f32::min(self.0.o(w), #max)},
-                    (Some(min), None) => quote! {f32::max(#min, self.0.o(w))},
-                    (Some(min), Some(max)) => quote! {f32::min(f32::max(#min, self.0.o(w)), #max)},
+                    (None, None) => quote! {self.0.o(w)?},
+                    (None, Some(max)) => quote! {f32::min(self.0.o(w)?, #max)},
+                    (Some(min), None) => quote! {f32::max(#min, self.0.o(w)?)},
+                    (Some(min), Some(max)) => quote! {f32::min(f32::max(#min, self.0.o(w)?), #max)},
                 };
                 quote! {#f32_out as #orig_ty}
             }
@@ -80,9 +80,9 @@ impl LivecodeFieldType {
             //ControlType::F32_3 => quote! {#name: self.#name.just_midi(m) },
             //ControlType::LinSrgba => quote! {#name:self.#name.just_midi(m) },
             ControlType::ColorUnclamped => {
-                quote! {#name: murrelet_livecode::livecode::ControlF32::hsva_unclamped_midi(&self.#name, m)}
+                quote! {#name: murrelet_livecode::livecode::ControlF32::hsva_unclamped_midi(&self.#name, m)?}
             }
-            _ => quote! {#name: self.#name.just_midi(m) as #orig_ty},
+            _ => quote! {#name: self.#name.just_midi(m)? as #orig_ty},
         }
     }
 
@@ -92,14 +92,14 @@ impl LivecodeFieldType {
             // ControlType::F32_2 => quote! {murrelet_livecode::livecode::ControlF32::vec2_midi(&self.0, m)},
             // ControlType::F32_3 => quote! {murrelet_livecode::livecode::ControlF32::vec3_midi(&self.0, m)},
             // ControlType::LinSrgba => quote! {murrelet_livecode::livecode::ControlF32::hsva_midi(&self.0, m)},
-            ControlType::F32_2 => quote! { self.0.just_midi(&m) },
-            ControlType::F32_3 => quote! { self.0.just_midi(&m) },
-            ControlType::Color => quote! { self.0.just_midi(&m) },
-            ControlType::LazyNodeF32 => quote! { self.0.just_midi(&w) },
+            ControlType::F32_2 => quote! { self.0.just_midi(&m)? },
+            ControlType::F32_3 => quote! { self.0.just_midi(&m)? },
+            ControlType::Color => quote! { self.0.just_midi(&m)? },
+            ControlType::LazyNodeF32 => quote! { self.0.just_midi(&w)? },
             ControlType::ColorUnclamped => {
-                quote! {murrelet_livecode::livecode::ControlF32::hsva_unclamped_midi(&self.0, m)}
+                quote! {murrelet_livecode::livecode::ControlF32::hsva_unclamped_midi(&self.0, m)?}
             }
-            _ => quote! {self.0.just_midi(m) as #orig_ty},
+            _ => quote! {self.0.just_midi(m)? as #orig_ty},
         }
     }
 
@@ -144,16 +144,16 @@ impl GenFinal for FieldTokensLivecode {
             }
 
             impl murrelet_livecode::livecode::LivecodeFromWorld<#name> for #new_ident {
-                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> #name {
-                    #name {
+                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
+                    Ok(#name {
                         #(#for_world,)*
-                    }
+                    })
                 }
 
-                fn just_midi(&self, m: &murrelet_livecode::livecode::TimelessLiveCodeWorldState) -> #name {
-                    #name {
+                fn just_midi(&self, m: &murrelet_livecode::livecode::TimelessLiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
+                    Ok(#name {
                         #(#for_timeless_world,)*
-                    }
+                    })
                 }
             }
 
@@ -190,13 +190,13 @@ impl GenFinal for FieldTokensLivecode {
                 #(#for_struct,)*
             }
             impl murrelet_livecode::livecode::LivecodeFromWorld<#name> for #new_ident {
-                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> #name {
+                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
                     match self {
                         #(#for_world,)*
                     }
                 }
 
-                fn just_midi(&self, m: &murrelet_livecode::livecode::TimelessLiveCodeWorldState) -> #name {
+                fn just_midi(&self, m: &murrelet_livecode::livecode::TimelessLiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
                     match self {
                         #(#for_timeless_world,)*
                     }
@@ -231,12 +231,12 @@ impl GenFinal for FieldTokensLivecode {
             #vis struct #new_ident(#(#for_struct,)*);
 
             impl murrelet_livecode::livecode::LivecodeFromWorld<#name> for #new_ident {
-                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> #name {
-                    #name(#(#for_world,)*)
+                fn o(&self, w: &murrelet_livecode::livecode::LiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
+                    Ok(#name(#(#for_world,)*))
                 }
 
-                fn just_midi(&self, m: &murrelet_livecode::livecode::TimelessLiveCodeWorldState) -> #name {
-                    #name(#(#for_timeless_world,)*)
+                fn just_midi(&self, m: &murrelet_livecode::livecode::TimelessLiveCodeWorldState) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
+                    Ok(#name(#(#for_timeless_world,)*))
                 }
             }
 
@@ -298,11 +298,11 @@ impl GenFinal for FieldTokensLivecode {
         };
 
         // for world
-        let for_world = quote! { #new_ident::#variant_ident(s) => #name::#variant_ident(s.o(w)) };
+        let for_world = quote! { #new_ident::#variant_ident(s) => Ok(#name::#variant_ident(s.o(w)?)) };
 
         // for timeless world
         let for_timeless_world =
-            quote! { #new_ident::#variant_ident(s) => #name::#variant_ident(s.just_midi(m)) };
+            quote! { #new_ident::#variant_ident(s) => Ok(#name::#variant_ident(s.just_midi(m)?)) };
 
         let for_to_control =
             quote! { #name::#variant_ident(s) => #new_ident::#variant_ident(s.to_control()) };
@@ -325,7 +325,7 @@ impl GenFinal for FieldTokensLivecode {
             quote! { #variant_ident }
         };
         let for_world: TokenStream2 = {
-            quote! { #new_ident::#variant_ident => #name::#variant_ident }
+            quote! { #new_ident::#variant_ident => Ok(#name::#variant_ident) }
         };
         let for_timeless_world = for_world.clone();
         let for_to_control = {
@@ -425,14 +425,14 @@ impl GenFinal for FieldTokensLivecode {
         };
         let for_world = {
             if should_o {
-                quote! {#name: self.#name.iter().map(|x| x.o(w)).collect::<Vec<_>>()}
+                quote! {#name: self.#name.iter().map(|x| x.o(w)).collect::<Result<Vec<_>, _>>()?}
             } else {
                 quote! {#name: self.#name.clone()}
             }
         };
         let for_timeless_world = {
             if should_o {
-                quote! {#name: self.#name.iter().map(|x| x.just_midi(m)).collect::<Vec<_>>()}
+                quote! {#name: self.#name.iter().map(|x| x.just_midi(m)).collect::<Result<Vec<_>, _>>()?}
             } else {
                 quote! {#name: self.#name.clone()}
             }
@@ -470,10 +470,10 @@ impl GenFinal for FieldTokensLivecode {
             quote! {#serde #name: #new_ty}
         };
         let for_world = {
-            quote! {#name: self.#name.o(w)}
+            quote! {#name: self.#name.o(w)?}
         };
         let for_timeless_world = {
-            quote! {#name: self.#name.just_midi(m)}
+            quote! {#name: self.#name.just_midi(m)?}
         };
         let for_to_control = {
             quote! {#name: self.#name.to_control()}
@@ -549,21 +549,21 @@ impl GenFinal for FieldTokensLivecode {
         let for_world = {
             quote! {#name: {
                 murrelet_livecode::unitcells::TmpUnitCells::new(
-                    self.#target.o(w),
+                    self.#target.o(w)?,
                     Box::new(self.#name.clone()),
                     #maybe_more_ctx,
                     #prefix
-                ).o(w)
+                ).o(w)?
             }}
         };
         let for_timeless_world = {
             quote! {#name: {
                 murrelet_livecode::unitcells::TmpUnitCells::new(
-                    self.#target.just_midi(m),
+                    self.#target.just_midi(m)?,
                     Box::new(self.#name.clone()),
                     #maybe_more_ctx,
                     #prefix
-                ).just_midi(m)
+                ).just_midi(m)?
             }}
         };
 
@@ -623,14 +623,14 @@ impl GenFinal for FieldTokensLivecode {
         };
         let for_world = {
             if should_o {
-                quote! {self.0.iter().map(|x| x.o(w)).collect::<Vec<_>>()}
+                quote! {self.0.iter().map(|x| x.o(w)).collect::<Result<Vec<_>, _>>()?}
             } else {
                 quote! {self.0.clone()}
             }
         };
         let for_timeless_world = {
             if should_o {
-                quote! {self.0.iter().map(|x| x.just_midi(m)).collect::<Vec<_>>()}
+                quote! {self.0.iter().map(|x| x.just_midi(m)).collect::<Result<Vec<_>, _>>()?}
             } else {
                 quote! {self.0.clone()}
             }

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_unitcell.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_unitcell.rs
@@ -121,8 +121,7 @@ impl GenFinal for FieldTokensUnitCell {
             #vis struct #lc_ident(#(#for_struct,)*);
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #lc_ident {
-                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> murrelet_livecode::livecode::LivecodeResult<#name> {
-                    let w = ctx.w.unwrap();
+                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     Ok(#name(#(#for_world,)*))
                 }
             }
@@ -154,8 +153,7 @@ impl GenFinal for FieldTokensUnitCell {
             }
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #lc_ident {
-                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> murrelet_livecode::livecode::LivecodeResult<#name> {
-                    let w = ctx.w.unwrap();
+                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     Ok(#name {
                         #(#for_world,)*
                     })
@@ -195,8 +193,7 @@ impl GenFinal for FieldTokensUnitCell {
             }
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #new_enum_ident {
-                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> murrelet_livecode::livecode::LivecodeResult<#name> {
-                    let w = ctx.w.unwrap();
+                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     Ok(match self {
                         #(#for_world,)*
                     })
@@ -218,8 +215,6 @@ impl GenFinal for FieldTokensUnitCell {
         _parent_idents: syn::Ident,
     ) -> FieldTokensUnitCell {
         let _serde = idents.serde(true);
-        // let name = idents.name();
-
         let ctrl = idents.control_type();
 
         let for_struct = {
@@ -388,7 +383,7 @@ impl GenFinal for FieldTokensUnitCell {
 
     fn from_newtype_recurse_struct_vec(idents: StructIdents) -> Self {
         let serde = idents.serde(true);
-        // let name = idents.name();
+
         let orig_ty = idents.orig_ty();
 
         let for_struct = {
@@ -503,7 +498,7 @@ impl GenFinal for FieldTokensUnitCell {
                     Box::new(self.#name.clone()),
                     #maybe_more_ctx,
                     #prefix
-                ).o(w)?
+                ).o(ctx)?
             }}
         };
 

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_unitcell.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_unitcell.rs
@@ -121,7 +121,7 @@ impl GenFinal for FieldTokensUnitCell {
             #vis struct #lc_ident(#(#for_struct,)*);
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #lc_ident {
-                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> Result<#name, String> {
+                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
                     let w = ctx.w.unwrap();
                     Ok(#name(#(#for_world,)*))
                 }
@@ -154,7 +154,7 @@ impl GenFinal for FieldTokensUnitCell {
             }
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #lc_ident {
-                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> Result<#name, String> {
+                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
                     let w = ctx.w.unwrap();
                     Ok(#name {
                         #(#for_world,)*
@@ -195,7 +195,7 @@ impl GenFinal for FieldTokensUnitCell {
             }
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #new_enum_ident {
-                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> Result<#name, String> {
+                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
                     let w = ctx.w.unwrap();
                     Ok(match self {
                         #(#for_world,)*
@@ -503,7 +503,7 @@ impl GenFinal for FieldTokensUnitCell {
                     Box::new(self.#name.clone()),
                     #maybe_more_ctx,
                     #prefix
-                ).o(w)
+                ).o(w)?
             }}
         };
 

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_unitcell.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_unitcell.rs
@@ -121,7 +121,7 @@ impl GenFinal for FieldTokensUnitCell {
             #vis struct #lc_ident(#(#for_struct,)*);
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #lc_ident {
-                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
+                fn eval(&self, ctx: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     Ok(#name(#(#for_world,)*))
                 }
             }
@@ -153,7 +153,7 @@ impl GenFinal for FieldTokensUnitCell {
             }
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #lc_ident {
-                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
+                fn eval(&self, ctx: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     Ok(#name {
                         #(#for_world,)*
                     })
@@ -193,7 +193,7 @@ impl GenFinal for FieldTokensUnitCell {
             }
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #new_enum_ident {
-                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
+                fn eval(&self, ctx: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     Ok(match self {
                         #(#for_world,)*
                     })

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_unitcell.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_unitcell.rs
@@ -121,7 +121,7 @@ impl GenFinal for FieldTokensUnitCell {
             #vis struct #lc_ident(#(#for_struct,)*);
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #lc_ident {
-                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
+                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     let w = ctx.w.unwrap();
                     Ok(#name(#(#for_world,)*))
                 }
@@ -154,7 +154,7 @@ impl GenFinal for FieldTokensUnitCell {
             }
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #lc_ident {
-                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
+                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     let w = ctx.w.unwrap();
                     Ok(#name {
                         #(#for_world,)*
@@ -195,7 +195,7 @@ impl GenFinal for FieldTokensUnitCell {
             }
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #new_enum_ident {
-                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> Result<#name, murrelet_livecode::livecode::LivecodeErr> {
+                fn eval(&self, ctx: &murrelet_livecode::unitcells::UnitCellEvalContext) -> murrelet_livecode::livecode::LivecodeResult<#name> {
                     let w = ctx.w.unwrap();
                     Ok(match self {
                         #(#for_world,)*

--- a/murrelet_perform/src/perform.rs
+++ b/murrelet_perform/src/perform.rs
@@ -3,6 +3,7 @@ use glam::{vec3, Mat4, Vec2};
 use murrelet_common::{LivecodeSrc, LivecodeSrcUpdateInput, MurreletAppInput};
 use murrelet_common::{MurreletColor, TransformVec2};
 use murrelet_livecode::boop::{BoopConfInner, BoopODEConf};
+use murrelet_livecode::state::{LivecodeTimingConfig, LivecodeWorldState};
 use std::{env, fs};
 
 use murrelet_common::run_id;
@@ -472,7 +473,7 @@ where
 pub struct LilLiveConfig<'a> {
     save_path: Option<&'a PathBuf>,
     run_id: u64,
-    w: &'a LiveCodeWorldState,
+    w: &'a LivecodeWorldState,
     app_config: &'a AppConfig,
 }
 
@@ -530,7 +531,7 @@ where
     boop_mng: BoopMng<ConfType, BoopConfType>,
     // sorry, the cache is mixed between boom_mng, but sometimes we need this
     cached_timeless_app_config: Option<AppConfigTiming>,
-    cached_world: Option<LiveCodeWorldState>,
+    cached_world: Option<LivecodeWorldState>,
 }
 impl<ConfType, ControlConfType, BoopConfType> LiveCoder<ConfType, ControlConfType, BoopConfType>
 where
@@ -706,10 +707,8 @@ where
         self.set_processed_config()
     }
 
-    pub fn _timeless_world(&self) -> LivecodeResult<LiveCodeWorldState> {
-        self.util.timeless_world(
-            &self.livecode_src,
-        )
+    pub fn _timeless_world(&self) -> LivecodeResult<LivecodeWorldState> {
+        self.util.timeless_world(&self.livecode_src)
     }
 
     pub fn _update_world(&mut self) -> LivecodeResult<()> {
@@ -725,7 +724,7 @@ where
         Ok(())
     }
 
-    pub fn world(&self) -> &LiveCodeWorldState {
+    pub fn world(&self) -> &LivecodeWorldState {
         self.cached_world.as_ref().unwrap()
     }
 

--- a/murrelet_perform/src/perform.rs
+++ b/murrelet_perform/src/perform.rs
@@ -542,7 +542,7 @@ where
         livecode_src: LivecodeSrc,
     ) -> LivecodeResult<LiveCoder<ConfType, ControlConfType, BoopConfType>> {
         let controlconfig = ControlConfType::parse(&conf)
-            .map_err(|err| LivecodeErr::new(format!("error parsing {}", err)))?;
+            .map_err(|err| LivecodeError::Raw(format!("error parsing {}", err)))?;
         Self::new_full(controlconfig, None, livecode_src)
     }
 
@@ -560,7 +560,7 @@ where
         controlconfig: ControlConfType,
         save_path: Option<PathBuf>,
         livecode_src: LivecodeSrc,
-    ) -> Result<LiveCoder<ConfType, ControlConfType, BoopConfType>, LivecodeErr> {
+    ) -> LivecodeResult<LiveCoder<ConfType, ControlConfType, BoopConfType>> {
         let run_id = run_id();
 
         let util = LiveCodeUtil::new()?;

--- a/murrelet_perform/src/perform.rs
+++ b/murrelet_perform/src/perform.rs
@@ -529,7 +529,7 @@ where
     prev_controlconfig: ControlConfType,
     boop_mng: BoopMng<ConfType, BoopConfType>,
     // sorry, the cache is mixed between boom_mng, but sometimes we need this
-    cached_timeless_app_config: Option<AppConfig>,
+    cached_timeless_app_config: Option<AppConfigTiming>,
     cached_world: Option<LiveCodeWorldState>,
 }
 impl<ConfType, ControlConfType, BoopConfType> LiveCoder<ConfType, ControlConfType, BoopConfType>
@@ -602,7 +602,7 @@ where
     pub fn set_processed_config(&mut self) -> LivecodeResult<()> {
         // set this one first, so we can use it to get the world
 
-        self.cached_timeless_app_config = Some(self._app_config().o(&self._timeless_world()?)?);
+        self.cached_timeless_app_config = Some(self._timing_config().o(&self._timeless_world()?)?);
         self._update_world()?;
 
         let w = self.world();
@@ -708,18 +708,16 @@ where
 
     pub fn _timeless_world(&self) -> LivecodeResult<LiveCodeWorldState> {
         self.util.timeless_world(
-            // &self.midi.values, &self.app_input.values, &self.blte.values
             &self.livecode_src,
-            // &self.cached_timeless_app_config.as_ref().map(|x| x.ctx.clone()).unwrap()
         )
     }
 
     pub fn _update_world(&mut self) -> LivecodeResult<()> {
         // this function should only be called after this is set! since the "set processed" is called right away
         let timeless_app_config = self.cached_timeless_app_config.as_ref().unwrap();
-        let ctx = &timeless_app_config.ctx;
+        let timing_conf = timeless_app_config.to_livecode();
 
-        let timing_conf = timeless_app_config.time.to_livecode();
+        let ctx = &self.controlconfig._app_config().ctx;
 
         let world = self.util.world(&self.livecode_src, &timing_conf, ctx)?;
 
@@ -731,12 +729,11 @@ where
         self.cached_world.as_ref().unwrap()
     }
 
-    pub fn _app_config(&self) -> &ControlAppConfig {
-        self.controlconfig._app_config()
+    pub fn _timing_config(&self) -> &ControlAppConfigTiming {
+        &self.controlconfig._app_config().time
     }
 
     pub fn app_config(&self) -> &AppConfig {
-        // self._app_config().o(&self.world())
         // use the cached one
         self.config().config_app_loc()
     }

--- a/murrelet_perform/src/reload.rs
+++ b/murrelet_perform/src/reload.rs
@@ -229,7 +229,7 @@ impl LiveCodeUtil {
         &'a self,
         livecode_src: &'a LivecodeSrc,
     ) -> LivecodeResult<LiveCodeWorldState> {
-        LiveCodeWorldState::new_timeless(self.global_funcs.clone(), livecode_src)
+        LiveCodeWorldState::new_timeless(&self.global_funcs, livecode_src)
     }
 
     pub fn world<'a>(
@@ -239,7 +239,7 @@ impl LiveCodeUtil {
         node: &Node,
     ) -> LivecodeResult<LiveCodeWorldState> {
         LiveCodeWorldState::new(
-            self.global_funcs.clone(),
+            &self.global_funcs,
             livecode_src,
             self.time(timing_conf),
             node.clone(),

--- a/murrelet_perform/src/reload.rs
+++ b/murrelet_perform/src/reload.rs
@@ -3,6 +3,7 @@ use evalexpr::{HashMapContext, Node};
 use murrelet_common::{LivecodeSrc, MurreletTime};
 use murrelet_livecode::expr::init_evalexpr_func_ctx;
 use murrelet_livecode::livecode::*;
+use murrelet_livecode::state::*;
 
 // todo, maybe only includde this if not wasm?
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -228,8 +229,8 @@ impl LiveCodeUtil {
     pub fn timeless_world<'a>(
         &'a self,
         livecode_src: &'a LivecodeSrc,
-    ) -> LivecodeResult<LiveCodeWorldState> {
-        LiveCodeWorldState::new_timeless(&self.global_funcs, livecode_src)
+    ) -> LivecodeResult<LivecodeWorldState> {
+        LivecodeWorldState::new_timeless(&self.global_funcs, livecode_src)
     }
 
     pub fn world<'a>(
@@ -237,8 +238,8 @@ impl LiveCodeUtil {
         livecode_src: &'a LivecodeSrc,
         timing_conf: &LivecodeTimingConfig,
         node: &Node,
-    ) -> LivecodeResult<LiveCodeWorldState> {
-        LiveCodeWorldState::new(
+    ) -> LivecodeResult<LivecodeWorldState> {
+        LivecodeWorldState::new(
             &self.global_funcs,
             livecode_src,
             self.time(timing_conf),

--- a/murrelet_perform/src/reload.rs
+++ b/murrelet_perform/src/reload.rs
@@ -166,7 +166,7 @@ pub struct LiveCodeUtil {
 }
 
 impl LiveCodeUtil {
-    pub fn new() -> Result<LiveCodeUtil, LivecodeErr> {
+    pub fn new() -> LivecodeResult<LiveCodeUtil> {
         Ok(LiveCodeUtil {
             info: LiveCodeConfigInfo::new(),
             timing: LiveCodeTiming::new(),
@@ -237,7 +237,7 @@ impl LiveCodeUtil {
         livecode_src: &'a LivecodeSrc,
         timing_conf: &LivecodeTimingConfig,
         node: &Node,
-    ) -> Result<LiveCodeWorldState, LivecodeErr> {
+    ) -> LivecodeResult<LiveCodeWorldState> {
         LiveCodeWorldState::new(
             self.global_funcs.clone(),
             livecode_src,

--- a/murrelet_perform/src/reload.rs
+++ b/murrelet_perform/src/reload.rs
@@ -228,8 +228,8 @@ impl LiveCodeUtil {
     pub fn timeless_world<'a>(
         &'a self,
         livecode_src: &'a LivecodeSrc,
-    ) -> TimelessLiveCodeWorldState {
-        TimelessLiveCodeWorldState::new(livecode_src)
+    ) -> LivecodeResult<LiveCodeWorldState> {
+        LiveCodeWorldState::new_timeless(self.global_funcs.clone(), livecode_src)
     }
 
     pub fn world<'a>(
@@ -238,6 +238,11 @@ impl LiveCodeUtil {
         timing_conf: &LivecodeTimingConfig,
         node: &Node,
     ) -> Result<LiveCodeWorldState, LivecodeErr> {
-        LiveCodeWorldState::new(self.global_funcs.clone(), livecode_src, self.time(timing_conf), node.clone())
+        LiveCodeWorldState::new(
+            self.global_funcs.clone(),
+            livecode_src,
+            self.time(timing_conf),
+            node.clone(),
+        )
     }
 }

--- a/murrelet_src_audio/src/audio_src.rs
+++ b/murrelet_src_audio/src/audio_src.rs
@@ -493,18 +493,4 @@ impl IsLivecodeSrc for AudioMng {
             ("fft6".to_owned(), LivecodeValue::Float(fft6 as f64)),
         ]
     }
-
-    fn to_just_midi(&self) -> Vec<(String, murrelet_common::LivecodeValue)> {
-        vec![
-            ("a".to_owned(), LivecodeValue::Float(0.0)),
-            ("ac".to_owned(), LivecodeValue::Float(0.0)),
-            ("fft0".to_owned(), LivecodeValue::Float(0.0)),
-            ("fft1".to_owned(), LivecodeValue::Float(0.0)),
-            ("fft2".to_owned(), LivecodeValue::Float(0.0)),
-            ("fft3".to_owned(), LivecodeValue::Float(0.0)),
-            ("fft4".to_owned(), LivecodeValue::Float(0.0)),
-            ("fft5".to_owned(), LivecodeValue::Float(0.0)),
-            ("fft6".to_owned(), LivecodeValue::Float(0.0)),
-        ]
-    }
 }

--- a/murrelet_src_midi/src/midi.rs
+++ b/murrelet_src_midi/src/midi.rs
@@ -42,16 +42,6 @@ impl IsLivecodeSrc for MidiMng {
         }
         vals
     }
-
-    fn to_just_midi(&self) -> Vec<(String, murrelet_common::LivecodeValue)> {
-        let mut vals = Vec::with_capacity(MIDI_COUNT * 3);
-        for idx in 0..MIDI_COUNT {
-            vals.push((format!("m{}", idx), LivecodeValue::Float(0.0)));
-            vals.push((format!("m{}t", idx), LivecodeValue::Bool(false)));
-            vals.push((format!("m{}f", idx), LivecodeValue::Bool(false)));
-        }
-        vals
-    }
 }
 
 pub struct MidiMng {


### PR DESCRIPTION
Simplifies some old ways of managing the context that's passed into expressions. Also switches to use Results in more places (e.g. I was just doing it in UnitCells, and now it's in both), and a new custom error.

Instead of writing toooo much here, I added some documentation to the README.

I'm not sure if this is quite the correct route, but I think it'll work for now.
 - I used to have an entire separate codepath for the case where time wasn't initialized yet (e.g. just to parse the time configuration, which is needed to initialize time.), so I set time as an optional value. I'm keeping the distinction via an `LivecodeWorldStateStage` which I don't totally love (I fought with lifetimes a bit too much to set it up the way I originally intended it.)

As usual, there are probably a lot of other improvements in this area. But flamegraph shows that I have much slower things that I should probably check out instead if I'm doing tidying, so until next time!


Also addresses https://github.com/jessstringham/murrelet/security/dependabot/1