### PR TITLE
Move general livecode types to their own module

### DIFF
--- a/examples/foolish_guillemot/src/lib.rs
+++ b/examples/foolish_guillemot/src/lib.rs
@@ -11,7 +11,7 @@ use murrelet_draw::{
     sequencers::*,
     style::{styleconf::*, MurreletPath},
 };
-use murrelet_livecode::livecode::LivecodeError;
+use murrelet_livecode::types::{AdditionalContextNode, LivecodeError};
 use wasm_bindgen::prelude::*;
 
 // from the wasm-rust tutorial, this let's you log messages to the js console
@@ -57,7 +57,7 @@ struct DrawingConfig {
     #[livecode(serde_default = "false")]
     debug: bool,
     sequencer: Sequencer,
-    ctx: UnitCellCtx,
+    ctx: AdditionalContextNode,
     #[livecode(src = "sequencer", ctx = "ctx")]
     node: UnitCells<SimpleTile>,
     offset: Vec2,

--- a/examples/murrelet_example/src/main.rs
+++ b/examples/murrelet_example/src/main.rs
@@ -1,5 +1,6 @@
 use murrelet::prelude::*;
 use murrelet_draw::{compass::*, sequencers::*, style::MurreletPath};
+use murrelet_livecode::types::*;
 use murrelet_src_audio::audio_src::AudioMng;
 //use murrelet_src_blte::blte::BlteMng;
 use murrelet_src_midi::midi::MidiMng;
@@ -27,7 +28,7 @@ struct DrawingConfig {
     #[livecode(serde_default = "false")]
     debug: bool,
     sequencer: Sequencer,
-    ctx: UnitCellCtx,
+    ctx: AdditionalContextNode,
     #[livecode(src = "sequencer", ctx = "ctx")]
     node: UnitCells<SimpleTile>,
 }

--- a/murrelet_livecode/src/lib.rs
+++ b/murrelet_livecode/src/lib.rs
@@ -4,4 +4,5 @@ pub mod expr;
 pub mod livecode;
 pub mod nestedit;
 pub mod state;
+pub mod types;
 pub mod unitcells;

--- a/murrelet_livecode/src/livecode.rs
+++ b/murrelet_livecode/src/livecode.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 use evalexpr::build_operator_tree;
-use evalexpr::EvalexprError;
 use evalexpr::Node;
 use glam::vec2;
 use glam::vec3;
@@ -12,33 +11,15 @@ use murrelet_common::MurreletColor;
 use serde::Deserialize;
 
 use crate::state::LivecodeWorldState;
-use crate::unitcells::LazyNodeF32;
-use crate::unitcells::LazyNodeF32Def;
+use crate::types::LazyNodeF32;
+use crate::types::LazyNodeF32Def;
+use crate::types::LivecodeResult;
 use crate::unitcells::{EvaluableUnitCell, UnitCellControlExprBool, UnitCellControlExprF32};
 
 // for default values
 pub fn empty_vec<T>() -> Vec<T> {
     Vec::new()
 }
-
-#[derive(Debug)]
-pub enum LivecodeError {
-    Raw(String), // my custom errors
-    EvalExpr(String, EvalexprError),
-}
-impl LivecodeError {}
-impl std::fmt::Display for LivecodeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LivecodeError::Raw(msg) => write!(f, "{}", msg),
-            LivecodeError::EvalExpr(msg, err) => write!(f, "{}: {}", msg, err),
-        }
-    }
-}
-
-impl std::error::Error for LivecodeError {}
-
-pub type LivecodeResult<T> = Result<T, LivecodeError>;
 
 pub trait LivecodeFromWorld<T> {
     fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<T>;

--- a/murrelet_livecode/src/nestedit.rs
+++ b/murrelet_livecode/src/nestedit.rs
@@ -7,7 +7,7 @@ use evalexpr::Node;
 use glam::{vec2, vec3, Vec2, Vec3};
 use murrelet_common::MurreletColor;
 
-use crate::unitcells::{LazyNodeF32, UnitCellCtx};
+use crate::types::{AdditionalContextNode, LazyNodeF32};
 
 #[derive(Debug, Clone)]
 pub struct NestedMod<'a> {
@@ -151,7 +151,7 @@ impl NestEditable for String {
     }
 }
 
-impl NestEditable for UnitCellCtx {
+impl NestEditable for AdditionalContextNode {
     fn nest_update(&self, _mods: NestedMod) -> Self {
         self.clone() // noop
     }

--- a/murrelet_livecode/src/state.rs
+++ b/murrelet_livecode/src/state.rs
@@ -2,9 +2,9 @@ use evalexpr::{HashMapContext, Node};
 use murrelet_common::*;
 
 use crate::{
-    expr::{ExprWorldContextValues, IntoExprWorldContext},
-    livecode::{LivecodeError, LivecodeResult},
-    unitcells::{MixedEvalDefs, UnitCellContext},
+    expr::{ExprWorldContextValues, IntoExprWorldContext, MixedEvalDefs},
+    types::{LivecodeError, LivecodeResult},
+    unitcells::UnitCellContext,
 };
 
 #[derive(Debug, Clone)]

--- a/murrelet_livecode/src/types.rs
+++ b/murrelet_livecode/src/types.rs
@@ -1,0 +1,178 @@
+use evalexpr::{build_operator_tree, EvalexprError, HashMapContext, Node};
+use murrelet_common::{IdxInRange, LivecodeValue};
+use serde::Deserialize;
+
+use crate::{
+    expr::{ExprWorldContextValues, MixedEvalDefs},
+    livecode::LivecodeFromWorld,
+    state::LivecodeWorldState,
+    unitcells::EvaluableUnitCell,
+};
+
+#[derive(Debug)]
+pub enum LivecodeError {
+    Raw(String), // my custom errors
+    EvalExpr(String, EvalexprError),
+}
+impl LivecodeError {}
+impl std::fmt::Display for LivecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LivecodeError::Raw(msg) => write!(f, "{}", msg),
+            LivecodeError::EvalExpr(msg, err) => write!(f, "{}: {}", msg, err),
+        }
+    }
+}
+
+impl std::error::Error for LivecodeError {}
+
+pub type LivecodeResult<T> = Result<T, LivecodeError>;
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(transparent)]
+pub struct AdditionalContextNode(Node);
+
+impl Default for AdditionalContextNode {
+    fn default() -> Self {
+        Self(build_operator_tree("").unwrap())
+    }
+}
+
+impl AdditionalContextNode {
+    pub fn eval_raw(&self, ctx: &mut HashMapContext) -> LivecodeResult<()> {
+        self.0
+            .eval_empty_with_context_mut(ctx)
+            .map_err(|err| LivecodeError::EvalExpr("error evaluating ctx".to_owned(), err))
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(transparent)]
+pub struct LazyNodeF32Def(pub Node);
+
+// #[derive(Debug, Deserialize, Clone)]
+// #[serde(untagged)]
+// pub enum LazyNodeF32Def {
+//     Int(i32),
+//     Bool(bool),
+//     Float(f32),
+//     Expr(Node),
+// }
+
+impl LazyNodeF32Def {
+    pub fn new(n: Node) -> Self {
+        Self(n)
+    }
+}
+
+impl LivecodeFromWorld<LazyNodeF32> for LazyNodeF32Def {
+    fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<LazyNodeF32> {
+        Ok(LazyNodeF32::new(self.0.clone(), w))
+    }
+}
+
+impl EvaluableUnitCell<LazyNodeF32> for LazyNodeF32Def {
+    fn eval(&self, ctx: &LivecodeWorldState) -> LivecodeResult<LazyNodeF32> {
+        Ok(LazyNodeF32::new(self.0.clone(), ctx))
+    }
+}
+
+// todo, figure out how to only build this context once per unitcell/etc
+
+#[derive(Debug, Clone)]
+pub struct LazyNodeF32Inner {
+    n: Node,
+    world: LivecodeWorldState,
+}
+impl LazyNodeF32Inner {
+    pub fn eval_with_ctx(&self, more_defs: &MixedEvalDefs) -> LivecodeResult<f32> {
+        // start with the global ctx
+        let mut ctx = self.world.clone();
+
+        ctx.update_with_defs(more_defs)?;
+
+        // modify it with the new data
+        // todo, handle the result better
+        more_defs.update_ctx(&mut ctx.ctx_mut())?;
+
+        // now grab the actual node
+        self.final_eval(&ctx.ctx())
+    }
+
+    pub fn final_eval(&self, ctx: &HashMapContext) -> LivecodeResult<f32> {
+        self.n
+            .eval_float_with_context(ctx)
+            .map(|x| x as f32)
+            .map_err(|err| LivecodeError::EvalExpr(format!("error evaluating lazy"), err))
+    }
+
+    pub fn eval_idx(&self, idx: IdxInRange, prefix: &str) -> LivecodeResult<f32> {
+        let pct = idx.pct();
+        let i = idx.i();
+        let total = idx.total();
+
+        // todo, make this more standardized
+        let vs: ExprWorldContextValues = ExprWorldContextValues::new(vec![
+            ("_p".to_owned(), LivecodeValue::Float(pct as f64)),
+            ("_i".to_owned(), LivecodeValue::Int(i as i64)),
+            ("_total".to_owned(), LivecodeValue::Int(total as i64)),
+        ]);
+
+        let mut ctx = self.world.ctx().clone();
+
+        vs.update_ctx_with_prefix(&mut ctx, prefix);
+
+        self.final_eval(&ctx)
+    }
+}
+
+// // expr that we can add things
+#[derive(Debug, Clone)]
+pub enum LazyNodeF32 {
+    Uninitialized,
+    Node(LazyNodeF32Inner),
+}
+
+impl Default for LazyNodeF32 {
+    fn default() -> Self {
+        LazyNodeF32::Uninitialized
+    }
+}
+
+impl LazyNodeF32 {
+    pub fn new(n: Node, world: &LivecodeWorldState) -> Self {
+        Self::Node(LazyNodeF32Inner {
+            n,
+            world: world.clone_to_lazy(),
+        })
+    }
+
+    pub fn n(&self) -> Option<&Node> {
+        match self {
+            LazyNodeF32::Uninitialized => None,
+            LazyNodeF32::Node(n) => Some(&n.n),
+        }
+    }
+
+    pub fn eval_with_ctx(&self, more_defs: &MixedEvalDefs) -> LivecodeResult<f32> {
+        self.node()?.eval_with_ctx(more_defs)
+    }
+
+    pub fn final_eval(&self, ctx: &HashMapContext) -> LivecodeResult<f32> {
+        self.node()?.final_eval(ctx)
+    }
+
+    pub fn eval_idx(&self, idx: IdxInRange, prefix: &str) -> LivecodeResult<f32> {
+        self.node()?.eval_idx(idx, prefix)
+    }
+
+    pub fn node(&self) -> LivecodeResult<&LazyNodeF32Inner> {
+        if let Self::Node(v) = self {
+            Ok(v)
+        } else {
+            Err(LivecodeError::Raw(
+                "trying to use uninitialized lazy node".to_owned(),
+            ))
+        }
+    }
+}

--- a/murrelet_livecode_macros/murrelet_livecode_derive/examples/tests.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/examples/tests.rs
@@ -1,6 +1,6 @@
 use glam::*;
 use murrelet_common::*;
-use murrelet_livecode::unitcells::*;
+use murrelet_livecode::{types::AdditionalContextNode, unitcells::*};
 use murrelet_livecode_derive::{Livecode, UnitCell};
 
 #[derive(Debug, Clone, Livecode, UnitCell, Default)]
@@ -23,7 +23,7 @@ struct TestNewType(Vec<EnumTest>);
 #[derive(Debug, Clone, Livecode)]
 struct SequencerTest {
     sequencer: SimpleSquareSequence,
-    ctx: UnitCellCtx,
+    ctx: AdditionalContextNode,
     #[livecode(src = "sequencer", ctx = "ctx")]
     node: UnitCells<TestNewType>,
 }

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_boop.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_boop.rs
@@ -18,7 +18,7 @@ impl BoopFieldType {
             ControlType::Color => quote! {murrelet_livecode::boop::BoopStateHsva},
 
             // nothing fancy here yet either..
-            ControlType::LazyNodeF32 => quote! {murrelet_livecode::unitcells::LazyNodeF32},
+            ControlType::LazyNodeF32 => quote! {murrelet_livecode::types::LazyNodeF32},
 
             // ControlType::LinSrgbaUnclamped => quote!{[murrelet_livecode::livecode::ControlF32; 4]},
             ControlType::Bool => quote! {bool}, // nothing fancy here yet

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_livecode.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_livecode.rs
@@ -19,8 +19,8 @@ impl LivecodeFieldType {
             ControlType::F32_3 => quote! {[murrelet_livecode::livecode::ControlF32; 3]},
             ControlType::Color => quote! {[murrelet_livecode::livecode::ControlF32; 4]},
             ControlType::ColorUnclamped => quote! {[murrelet_livecode::livecode::ControlF32; 4]},
-            ControlType::EvalExpr => quote! {murrelet_livecode::expr::ControlExprF32},
-            ControlType::LazyNodeF32 => quote! {murrelet_livecode::unitcells::LazyNodeF32Def},
+            // ControlType::EvalExpr => quote! {murrelet_livecode::expr::ControlExprF32},
+            ControlType::LazyNodeF32 => quote! {murrelet_livecode::types::LazyNodeF32Def},
         }
     }
 
@@ -110,7 +110,7 @@ impl GenFinal for FieldTokensLivecode {
             }
 
             impl murrelet_livecode::livecode::LivecodeFromWorld<#name> for #new_ident {
-                fn o(&self, w: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
+                fn o(&self, w: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::types::LivecodeResult<#name> {
                     Ok(#name {
                         #(#for_world,)*
                     })
@@ -149,7 +149,7 @@ impl GenFinal for FieldTokensLivecode {
                 #(#for_struct,)*
             }
             impl murrelet_livecode::livecode::LivecodeFromWorld<#name> for #new_ident {
-                fn o(&self, w: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
+                fn o(&self, w: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::types::LivecodeResult<#name> {
                     match self {
                         #(#for_world,)*
                     }
@@ -183,7 +183,7 @@ impl GenFinal for FieldTokensLivecode {
             #vis struct #new_ident(#(#for_struct,)*);
 
             impl murrelet_livecode::livecode::LivecodeFromWorld<#name> for #new_ident {
-                fn o(&self, w: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
+                fn o(&self, w: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::types::LivecodeResult<#name> {
                     Ok(#name(#(#for_world,)*))
                 }
             }

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_unitcell.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_unitcell.rs
@@ -25,7 +25,7 @@ impl UnitCellFieldType {
                 quote! {[murrelet_livecode::unitcells::UnitCellControlExprF32; 4]}
             }
             ControlType::LazyNodeF32 => {
-                quote! { murrelet_livecode::unitcells::LazyNodeF32Def }
+                quote! { murrelet_livecode::types::LazyNodeF32Def }
             }
             // ControlType::LinSrgbaUnclamped => quote!{[murrelet_livecode::livecode::ControlF32; 4]},
             _ => panic!("unitcell doesn't have this one yet"),
@@ -121,7 +121,7 @@ impl GenFinal for FieldTokensUnitCell {
             #vis struct #lc_ident(#(#for_struct,)*);
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #lc_ident {
-                fn eval(&self, ctx: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
+                fn eval(&self, ctx: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::types::LivecodeResult<#name> {
                     Ok(#name(#(#for_world,)*))
                 }
             }
@@ -153,7 +153,7 @@ impl GenFinal for FieldTokensUnitCell {
             }
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #lc_ident {
-                fn eval(&self, ctx: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
+                fn eval(&self, ctx: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::types::LivecodeResult<#name> {
                     Ok(#name {
                         #(#for_world,)*
                     })
@@ -193,7 +193,7 @@ impl GenFinal for FieldTokensUnitCell {
             }
 
             impl murrelet_livecode::unitcells::EvaluableUnitCell<#name> for #new_enum_ident {
-                fn eval(&self, ctx: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::livecode::LivecodeResult<#name> {
+                fn eval(&self, ctx: &murrelet_livecode::state::LivecodeWorldState) -> murrelet_livecode::types::LivecodeResult<#name> {
                     Ok(match self {
                         #(#for_world,)*
                     })

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/parser.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/parser.rs
@@ -315,7 +315,6 @@ pub enum ControlType {
     F32_3,
     Color,
     ColorUnclamped,
-    EvalExpr,
     LazyNodeF32,
 }
 
@@ -370,9 +369,9 @@ impl HowToControlThis {
                 OverrideOrInferred::Override,
                 RecursiveControlType::Vec,
             ),
-            "expr" => {
-                HowToControlThis::WithType(OverrideOrInferred::Override, ControlType::EvalExpr)
-            }
+            // "expr" => {
+            //     HowToControlThis::WithType(OverrideOrInferred::Override, ControlType::EvalExpr)
+            // }
             "unitcell" => HowToControlThis::WithRecurse(
                 OverrideOrInferred::Override,
                 RecursiveControlType::UnitCell,
@@ -402,10 +401,7 @@ impl HowToControlThis {
             "MurreletColor" => {
                 HowToControlThis::WithType(OverrideOrInferred::Inferred, ControlType::Color)
             }
-            "ExprWorldF32" => {
-                HowToControlThis::WithType(OverrideOrInferred::Inferred, ControlType::EvalExpr)
-            }
-            "UnitCellCtx" => HowToControlThis::WithNone(OverrideOrInferred::Inferred),
+            "AdditionalContextNode" => HowToControlThis::WithNone(OverrideOrInferred::Inferred),
             "UnitCells" => HowToControlThis::WithRecurse(
                 OverrideOrInferred::Inferred,
                 RecursiveControlType::UnitCell,

--- a/murrelet_perform/src/perform.rs
+++ b/murrelet_perform/src/perform.rs
@@ -4,6 +4,7 @@ use murrelet_common::{LivecodeSrc, LivecodeSrcUpdateInput, MurreletAppInput};
 use murrelet_common::{MurreletColor, TransformVec2};
 use murrelet_livecode::boop::{BoopConfInner, BoopODEConf};
 use murrelet_livecode::state::{LivecodeTimingConfig, LivecodeWorldState};
+use murrelet_livecode::types::{LivecodeError, LivecodeResult};
 use std::{env, fs};
 
 use murrelet_common::run_id;

--- a/murrelet_perform/src/reload.rs
+++ b/murrelet_perform/src/reload.rs
@@ -2,8 +2,8 @@
 use evalexpr::{HashMapContext, Node};
 use murrelet_common::{LivecodeSrc, MurreletTime};
 use murrelet_livecode::expr::init_evalexpr_func_ctx;
-use murrelet_livecode::livecode::*;
 use murrelet_livecode::state::*;
+use murrelet_livecode::types::LivecodeResult;
 
 // todo, maybe only includde this if not wasm?
 use std::time::{SystemTime, UNIX_EPOCH};


### PR DESCRIPTION
move the general types into a `types` file, delete some unused code.