### PR TITLE
Fix web demo

### DIFF
--- a/examples/foolish_guillemot/Cargo.toml
+++ b/examples/foolish_guillemot/Cargo.toml
@@ -28,7 +28,7 @@ murrelet_common = { path = "../../murrelet_common/" }
 murrelet_livecode = { path = "../../murrelet_livecode/" }
 murrelet_livecode_macros = { path = "../../murrelet_livecode_macros/" }
 murrelet_livecode_derive = { path = "../../murrelet_livecode_macros/murrelet_livecode_derive/" }
-murrelet_perform = { path = "../../murrelet_perform/" }
+murrelet_perform = { path = "../../murrelet_perform/", features = ["for_the_web"] }
 murrelet_draw = { path = "../../murrelet_draw/" }
 murrelet_svg = { path = "../../murrelet_svg/" }
 murrelet_gpu = { path = "../../murrelet_gpu/", features = ["no_nannou"] }

--- a/examples/foolish_guillemot/src/lib.rs
+++ b/examples/foolish_guillemot/src/lib.rs
@@ -15,7 +15,7 @@ use murrelet_livecode::types::{AdditionalContextNode, LivecodeError};
 use wasm_bindgen::prelude::*;
 
 // from the wasm-rust tutorial, this let's you log messages to the js console
-// extern crate web_sys;
+extern crate web_sys;
 
 // A macro to provide `println!(..)`-style syntax for `console.log` logging.
 // macro_rules! log {
@@ -102,12 +102,17 @@ impl MurreletModel {
 
         let livecode_src = LivecodeSrc::new(vec![Box::new(AppInputValues::new(false))]);
 
+        // log!("{:?}", livecode_src.to_world_vals());
+
         match LiveCode::new_web(conf, livecode_src) {
             Ok(livecode) => {
                 let r = MurreletModel { livecode };
                 WasmMurreletModelResult::ok(r)
             }
-            Err(e) => WasmMurreletModelResult::err(e),
+            Err(e) => {
+                // log!("{}", e);
+                WasmMurreletModelResult::err(e)
+            }
         }
     }
 

--- a/examples/foolish_guillemot/src/lib.rs
+++ b/examples/foolish_guillemot/src/lib.rs
@@ -15,7 +15,7 @@ use murrelet_livecode::types::{AdditionalContextNode, LivecodeError};
 use wasm_bindgen::prelude::*;
 
 // from the wasm-rust tutorial, this let's you log messages to the js console
-extern crate web_sys;
+// extern crate web_sys;
 
 // A macro to provide `println!(..)`-style syntax for `console.log` logging.
 // macro_rules! log {
@@ -102,17 +102,12 @@ impl MurreletModel {
 
         let livecode_src = LivecodeSrc::new(vec![Box::new(AppInputValues::new(false))]);
 
-        // log!("{:?}", livecode_src.to_world_vals());
-
         match LiveCode::new_web(conf, livecode_src) {
             Ok(livecode) => {
                 let r = MurreletModel { livecode };
                 WasmMurreletModelResult::ok(r)
             }
-            Err(e) => {
-                // log!("{}", e);
-                WasmMurreletModelResult::err(e)
-            }
+            Err(e) => WasmMurreletModelResult::err(e),
         }
     }
 

--- a/murrelet_perform/Cargo.toml
+++ b/murrelet_perform/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 authors = ["Jessica Stringham <jessica@thisxorthat.art>"]
 repository = "https://github.com/jessstringham/murrelet.git"
 
+[features]
+for_the_web = []
+
 [dependencies]
 murrelet_common = { path = "../murrelet_common/" }
 murrelet_livecode = { path = "../murrelet_livecode/" }

--- a/murrelet_perform/src/perform.rs
+++ b/murrelet_perform/src/perform.rs
@@ -126,13 +126,27 @@ fn _default_realtime() -> ControlBool {
     ControlBool::Raw(true)
 }
 fn _default_bg_alpha() -> ControlF32 {
-    ControlF32::force_from_str("slog(m15, -5.0, 0.0)")
+    ControlF32::Raw(0.2)
 } // defaults to midi
 fn _default_capture_frame() -> ControlBool {
-    ControlBool::force_from_str("kSf")
+    #[cfg(feature = "for_the_web")]
+    {
+        ControlBool::Raw(false) // can't actually capture the frame..
+    }
+    #[cfg(not(feature = "for_the_web"))]
+    {
+        ControlBool::force_from_str("kSf")
+    }
 } // usually want to leave this as midi
 fn _default_clear_bg() -> ControlBool {
-    ControlBool::force_from_str("m12") // todo, make this relax if missing
+    #[cfg(feature = "for_the_web")]
+    {
+        ControlBool::Raw(false)
+    }
+    #[cfg(not(feature = "for_the_web"))]
+    {
+        ControlBool::force_from_str("m12") // todo, make this relax if missing
+    }
 } // usually want to leave this as midi
 fn _default_bg_color() -> [ControlF32; 4] {
     [
@@ -276,11 +290,25 @@ impl Default for ControlSvgConfig {
 }
 
 fn _default_gpu_debug_next() -> ControlBool {
-    ControlBool::force_from_str("kFf")
+    #[cfg(feature = "for_the_web")]
+    {
+        ControlBool::Raw(false)
+    }
+    #[cfg(not(feature = "for_the_web"))]
+    {
+        ControlBool::force_from_str("kFf")
+    }
 }
 
 fn _default_gpu_debug() -> ControlBool {
-    ControlBool::force_from_str("kDf")
+    #[cfg(feature = "for_the_web")]
+    {
+        ControlBool::Raw(false)
+    }
+    #[cfg(not(feature = "for_the_web"))]
+    {
+        ControlBool::force_from_str("kDf")
+    }
 }
 
 fn _default_gpu_color_channel() -> ControlF32 {
@@ -308,7 +336,14 @@ impl Default for ControlGpuConfig {
 }
 
 fn _default_should_reset() -> ControlBool {
-    ControlBool::force_from_str("kVt")
+    #[cfg(feature = "for_the_web")]
+    {
+        ControlBool::Raw(false)
+    }
+    #[cfg(not(feature = "for_the_web"))]
+    {
+        ControlBool::force_from_str("kVt")
+    }
 }
 
 #[allow(dead_code)]

--- a/murrelet_perform/src/perform.rs
+++ b/murrelet_perform/src/perform.rs
@@ -126,8 +126,15 @@ fn _default_realtime() -> ControlBool {
     ControlBool::Raw(true)
 }
 fn _default_bg_alpha() -> ControlF32 {
-    ControlF32::Raw(0.2)
-} // defaults to midi
+    #[cfg(feature = "for_the_web")]
+    {
+        ControlF32::Raw(1.0) // also not really used on the web atm
+    }
+    #[cfg(not(feature = "for_the_web"))]
+    {
+        ControlF32::force_from_str("slog(m15, -5.0, 0.0)")
+    }
+}
 fn _default_capture_frame() -> ControlBool {
     #[cfg(feature = "for_the_web")]
     {


### PR DESCRIPTION
#2 somehow made the expr more picky about missing variables, like my default app config's midi and keyboard on the web. (I should probably just have a separate stripped down `perform`  for the web and this repo and such.) anyways, this works around it by setting a "web" feature (I alsooo should consolidate the features)