### PR TITLE
Repeatable vec

### DIFF
--- a/murrelet_livecode/src/expr.rs
+++ b/murrelet_livecode/src/expr.rs
@@ -182,6 +182,8 @@ impl ExprWorldContextValues {
     pub fn update_ctx_with_prefix(&self, ctx: &mut HashMapContext, prefix: &str) {
         for (identifier, value) in &self.0 {
             let name = format!("{}{}", prefix, identifier);
+            // println!("name {:?}", name);
+            // println!("value {:?}", value);
             add_variable_or_prefix_it(&name, lc_val_to_expr(value), ctx);
         }
     }

--- a/murrelet_livecode/src/expr.rs
+++ b/murrelet_livecode/src/expr.rs
@@ -4,7 +4,9 @@ use std::{f64::consts::PI, fmt::Debug};
 use evalexpr::*;
 use glam::{vec2, Vec2};
 use itertools::Itertools;
-use murrelet_common::{clamp, ease, lerp, map_range, print_expect, smoothstep, LivecodeValue};
+use murrelet_common::{
+    clamp, ease, lerp, map_range, print_expect, smoothstep, IdxInRange, LivecodeValue,
+};
 use noise::{NoiseFn, Perlin};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
@@ -186,6 +188,19 @@ impl ExprWorldContextValues {
 
     pub fn set_val(&mut self, name: &str, val: LivecodeValue) {
         self.0.push((name.to_owned(), val))
+    }
+
+    pub fn new_from_idx(idx: IdxInRange) -> Self {
+        Self::new(vec![
+            ("i".to_string(), LivecodeValue::Int(idx.i() as i64)),
+            ("if".to_string(), LivecodeValue::Float(idx.i() as f64)),
+            ("pct".to_string(), LivecodeValue::Float(idx.pct() as f64)),
+            ("total".to_string(), LivecodeValue::Int(idx.total() as i64)),
+            (
+                "totalf".to_string(),
+                LivecodeValue::Float(idx.total() as f64),
+            ),
+        ])
     }
 }
 

--- a/murrelet_livecode/src/livecode.rs
+++ b/murrelet_livecode/src/livecode.rs
@@ -25,6 +25,24 @@ pub trait LivecodeFromWorld<T> {
     fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<T>;
 }
 
+impl LivecodeFromWorld<f32> for ControlF32 {
+    fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<f32> {
+        self._o(w)
+    }
+}
+
+impl LivecodeFromWorld<usize> for ControlF32 {
+    fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<usize> {
+        Ok(self._o(w)? as usize)
+    }
+}
+
+impl LivecodeFromWorld<u64> for ControlF32 {
+    fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<u64> {
+        Ok(self._o(w)? as u64)
+    }
+}
+
 impl LivecodeFromWorld<Vec2> for [ControlF32; 2] {
     fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<Vec2> {
         Ok(vec2(self[0].o(w)?, self[1].o(w)?))
@@ -186,7 +204,7 @@ impl ControlF32 {
         }
     }
 
-    pub fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<f32> {
+    pub fn _o(&self, w: &LivecodeWorldState) -> LivecodeResult<f32> {
         self.to_unitcell_control().eval(&w)
     }
 }

--- a/murrelet_livecode/src/livecode.rs
+++ b/murrelet_livecode/src/livecode.rs
@@ -25,24 +25,6 @@ pub trait LivecodeFromWorld<T> {
     fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<T>;
 }
 
-impl LivecodeFromWorld<f32> for ControlF32 {
-    fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<f32> {
-        self._o(w)
-    }
-}
-
-impl LivecodeFromWorld<usize> for ControlF32 {
-    fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<usize> {
-        Ok(self._o(w)? as usize)
-    }
-}
-
-impl LivecodeFromWorld<u64> for ControlF32 {
-    fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<u64> {
-        Ok(self._o(w)? as u64)
-    }
-}
-
 impl LivecodeFromWorld<Vec2> for [ControlF32; 2] {
     fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<Vec2> {
         Ok(vec2(self[0].o(w)?, self[1].o(w)?))
@@ -204,7 +186,7 @@ impl ControlF32 {
         }
     }
 
-    pub fn _o(&self, w: &LivecodeWorldState) -> LivecodeResult<f32> {
+    pub fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<f32> {
         self.to_unitcell_control().eval(&w)
     }
 }

--- a/murrelet_livecode/src/state.rs
+++ b/murrelet_livecode/src/state.rs
@@ -119,6 +119,16 @@ impl LivecodeWorldState {
         more_defs.update_ctx(&mut self.ctx_mut())
     }
 
+    pub fn clone_with_vals(
+        &self,
+        expr: ExprWorldContextValues,
+        prefix: &str,
+    ) -> LivecodeResult<LivecodeWorldState> {
+        let mut lazy = self.clone_to_lazy(); // eh just need to clone
+        expr.update_ctx_with_prefix(&mut lazy.ctx_mut(), prefix);
+        Ok(lazy)
+    }
+
     pub fn clone_to_unitcell(
         &self,
         unit_cell_ctx: &UnitCellContext,

--- a/murrelet_livecode/src/types.rs
+++ b/murrelet_livecode/src/types.rs
@@ -208,9 +208,9 @@ impl LazyNodeF32 {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ControlVecElementRepeat<Source> {
     repeat: usize,
+    #[serde(default)]
     prefix: String,
     what: Vec<Source>,
-    // _marker: PhantomData<Target>,
 }
 
 // hack to simplify this, but should just refactor a lot
@@ -250,9 +250,9 @@ impl<Source> ControlVecElementRepeat<Source> {
         let mut result = Vec::with_capacity(self.repeat * self.what.len());
 
         let prefix = if self.prefix.is_empty() {
-            format!("{}_", self.prefix)
-        } else {
             "i_".to_string()
+        } else {
+            format!("{}_", self.prefix)
         };
 
         for i in 0..self.repeat {
@@ -276,9 +276,9 @@ impl<Source> ControlVecElementRepeat<Source> {
         let mut result = Vec::with_capacity(self.repeat * self.what.len());
 
         let prefix = if self.prefix.is_empty() {
-            format!("{}_", self.prefix)
-        } else {
             "i_".to_string()
+        } else {
+            format!("{}_", self.prefix)
         };
 
         for i in 0..self.repeat {

--- a/murrelet_livecode/src/types.rs
+++ b/murrelet_livecode/src/types.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use evalexpr::{build_operator_tree, EvalexprError, HashMapContext, Node};
 use murrelet_common::{IdxInRange, LivecodeValue};
 use serde::Deserialize;
@@ -201,6 +203,58 @@ impl LazyNodeF32 {
             Err(LivecodeError::Raw(
                 "trying to use uninitialized lazy node".to_owned(),
             ))
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ControlVecElementRepeat<Source, Target> {
+    repeat: usize,
+    #[serde(default)]
+    prefix: String,
+    what: Vec<Source>,
+    _marker: PhantomData<Target>,
+}
+impl<Source: LivecodeFromWorld<Target>, Target> LivecodeFromWorld<Vec<Target>>
+    for ControlVecElementRepeat<Source, Target>
+{
+    fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<Vec<Target>> {
+        let mut result = Vec::with_capacity(self.repeat * self.what.len());
+
+        let prefix = if self.prefix.is_empty() {
+            format!("{}_", self.prefix)
+        } else {
+            "i_".to_string()
+        };
+
+        for i in 0..self.repeat {
+            let idx = IdxInRange::new(i, self.repeat);
+            let expr = ExprWorldContextValues::new_from_idx(idx);
+
+            let new_w = w.clone_with_vals(expr, &prefix)?;
+
+            for src in &self.what {
+                let o = src.o(&new_w);
+                result.push(o?);
+            }
+        }
+        Ok(result)
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum ControlVecElement<Source, Target> {
+    Raw(Source),
+    Repeat(ControlVecElementRepeat<Source, Target>),
+}
+impl<Source: LivecodeFromWorld<Target>, Target> LivecodeFromWorld<Vec<Target>>
+    for ControlVecElement<Source, Target>
+{
+    fn o(&self, w: &LivecodeWorldState) -> LivecodeResult<Vec<Target>> {
+        match self {
+            ControlVecElement::Raw(c) => Ok(vec![c.o(w)?]),
+            ControlVecElement::Repeat(c) => c.o(w),
         }
     }
 }

--- a/murrelet_livecode_macros/murrelet_livecode_derive/examples/tests.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/examples/tests.rs
@@ -8,6 +8,7 @@ pub struct SomethingElse {
     a_number: f32,
     b_color: MurreletColor,
     c_vec2: Vec2,
+    something: Vec<f32>,
 }
 
 #[derive(Debug, Clone, Livecode, UnitCell, Default)]
@@ -22,7 +23,6 @@ struct TestNewType(Vec<EnumTest>);
 
 #[derive(Debug, Clone, Livecode)]
 struct SequencerTest {
-    something: Vec<TestNewType>,
     sequencer: SimpleSquareSequence,
     ctx: AdditionalContextNode,
     #[livecode(src = "sequencer", ctx = "ctx")]

--- a/murrelet_livecode_macros/murrelet_livecode_derive/examples/tests.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/examples/tests.rs
@@ -22,6 +22,7 @@ struct TestNewType(Vec<EnumTest>);
 
 #[derive(Debug, Clone, Livecode)]
 struct SequencerTest {
+    something: Vec<TestNewType>,
     sequencer: SimpleSquareSequence,
     ctx: AdditionalContextNode,
     #[livecode(src = "sequencer", ctx = "ctx")]

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_unitcell.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_unitcell.rs
@@ -338,31 +338,33 @@ impl GenFinal for FieldTokensUnitCell {
 
         let for_struct = {
             let new_ty = {
-                let ref_lc_ident = if let DataFromType {
+                let source_type = if let DataFromType {
                     second_type: Some(second_ty_ident),
                     ..
                 } = ident_from_type(&orig_ty)
                 {
-                    let infer = HowToControlThis::from_type_str(
-                        second_ty_ident.clone().to_string().as_ref(),
-                    );
-
-                    match infer {
-                        HowToControlThis::WithType(_, c) => UnitCellFieldType(c).to_token(),
-                        HowToControlThis::WithRecurse(_, RecursiveControlType::Struct) => {
-                            let name = Self::new_ident(second_ty_ident.clone());
-                            quote! {#name}
-                        }
-                        HowToControlThis::WithNone(_) => {
-                            let name = Self::new_ident(second_ty_ident.clone());
-                            quote! {#name}
-                        }
-                        e => panic!("need vec something {:?}", e),
-                    }
+                    second_ty_ident
                 } else {
                     panic!("vec missing second type");
                 };
-                quote! {Vec<#ref_lc_ident>}
+
+                let infer =
+                    HowToControlThis::from_type_str(source_type.clone().to_string().as_ref());
+
+                let target_type = match infer {
+                    HowToControlThis::WithType(_, c) => UnitCellFieldType(c).to_token(),
+                    HowToControlThis::WithRecurse(_, RecursiveControlType::Struct) => {
+                        let name = Self::new_ident(source_type.clone());
+                        quote! {#name}
+                    }
+                    HowToControlThis::WithNone(_) => {
+                        let name = Self::new_ident(source_type.clone());
+                        quote! {#name}
+                    }
+                    e => panic!("need vec something {:?}", e),
+                };
+
+                quote! {Vec<murrelet_livecode::types::ControlVecElement<#source_type, #target_type>>}
             };
             quote! {#serde #name: #new_ty}
         };

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_unitcell.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_unitcell.rs
@@ -338,7 +338,7 @@ impl GenFinal for FieldTokensUnitCell {
 
         let for_struct = {
             let new_ty = {
-                let source_type = if let DataFromType {
+                let target_type = if let DataFromType {
                     second_type: Some(second_ty_ident),
                     ..
                 } = ident_from_type(&orig_ty)
@@ -349,31 +349,31 @@ impl GenFinal for FieldTokensUnitCell {
                 };
 
                 let infer =
-                    HowToControlThis::from_type_str(source_type.clone().to_string().as_ref());
+                    HowToControlThis::from_type_str(target_type.clone().to_string().as_ref());
 
-                let target_type = match infer {
+                let src_type = match infer {
                     HowToControlThis::WithType(_, c) => UnitCellFieldType(c).to_token(),
                     HowToControlThis::WithRecurse(_, RecursiveControlType::Struct) => {
-                        let name = Self::new_ident(source_type.clone());
+                        let name = Self::new_ident(target_type.clone());
                         quote! {#name}
                     }
                     HowToControlThis::WithNone(_) => {
-                        let name = Self::new_ident(source_type.clone());
+                        let name = Self::new_ident(target_type.clone());
                         quote! {#name}
                     }
                     e => panic!("need vec something {:?}", e),
                 };
 
-                quote! {Vec<murrelet_livecode::types::ControlVecElement<#source_type, #target_type>>}
+                quote! {Vec<murrelet_livecode::types::ControlVecElement<#src_type>>}
             };
             quote! {#serde #name: #new_ty}
         };
         let for_world = {
-            quote! {#name: self.#name.iter().map(|x| x.eval(ctx)).collect::<Result<Vec<_>, _>>()?}
+            quote! {#name: vec![] } //self.#name.iter().map(|x| x.eval(ctx)).collect::<Result<Vec<_>, _>>()?.into_iter().flatten().collect()}
         };
 
         let for_inverted_world = {
-            quote! {#name: self.#name.iter().map(|x| x.to_unitcell_input()).collect::<Vec<_>>()}
+            quote! {#name: vec![] } //self.#name.iter().map(|x| x.to_unitcell_input()).collect::<Vec<_>>().into_iter().flatten().collect()}
         };
 
         FieldTokensUnitCell {


### PR DESCRIPTION
something I've been wanting: now anything that's a Vec can now have expanding things. the first thing is "repeat" which just repeats something a few times. but! you can also inject the index of the repeat, kinda like a unitcell-lite.

but some rambling to myself

well, on one hand it's a lot easier to drop in additional variables into the contexts (for better or for worse. this might get confusing, but ah, maybe can build something into the config viewer that will tell you which vars you have in scope?)

but the split between world and unit cell doesn't make that much sense anymore, and it does make it harder to implement things (controlf32 doesn't have a livecodefromworld, but does have a unit cell. if I want to have a blanket "meh just evaluate", i can't do it for both things with a world and unit cell implementation.)
I wonder if there's some way to just squish livecode and unit cell into one implementation (the draw_ctx has a separate thing for a unit cell, which I think could be nice to know whether you're drawing to the global coordinates or the unit cell's coordinates.) but like I wonder if derive_livecode and derive_unitcell are more or less the same at this point.