### PR TITLE
some changes to lazy

### DIFF
--- a/murrelet_livecode/src/expr.rs
+++ b/murrelet_livecode/src/expr.rs
@@ -299,17 +299,6 @@ impl GuideType {
     }
 }
 
-// hmm can i deprecate this? i like being explicit...
-// pub fn add_variable_or_prefix_it(identifier: &str, value: Value, ctx: &mut HashMapContext) {
-//     if ctx.get_value(identifier).is_some() {
-//         add_variable_or_prefix_it(&format!("_{}", identifier), value, ctx);
-//     } else {
-//         let r = ctx.set_value(identifier.to_owned(), value.clone());
-//         print_expect(r, "couldn't set variable");
-//     }
-// }
-
-// todo, hrm, this is awkward
 #[derive(Debug, Clone)]
 pub struct MixedEvalDefs {
     vals: ExprWorldContextValues,
@@ -343,5 +332,16 @@ impl MixedEvalDefs {
 
     pub fn add_node(&mut self, node: AdditionalContextNode) {
         self.nodes.push(node)
+    }
+
+    pub fn combine(&self, more_defs: &MixedEvalDefs) -> Self {
+        let mut c = self.clone();
+        more_defs
+            .nodes
+            .iter()
+            .for_each(|node| c.nodes.push(node.clone()));
+        c.set_vals(more_defs.vals.clone());
+
+        c
     }
 }

--- a/murrelet_livecode/src/lazy.rs
+++ b/murrelet_livecode/src/lazy.rs
@@ -85,26 +85,6 @@ impl LazyNodeF32Inner {
             .map(|x| x as f32)
             .map_err(|err| LivecodeError::EvalExpr(format!("error evaluating lazy"), err))
     }
-
-    // pub fn eval_with_ctx(&self) -> LivecodeResult<f32> {
-    //     // start with the global ctx
-    //     let mut ctx = self.world.clone();
-
-    //     ctx.update_with_defs(&self.more_defs)?;
-
-    //     // modify it with the new data
-    //     // todo, handle the result better
-    //     self.more_defs.update_ctx(&mut ctx.ctx_mut())?;
-
-    //     // now grab the actual node
-    //     self.final_eval(&ctx.ctx())
-    // }
-
-    // pub fn eval_with_expr_world_values(&self, vs: ExprWorldContextValues) -> LivecodeResult<f32> {
-    //     let mut ctx = self.build_ctx();
-    //     vs.update_ctx(&mut ctx)?;
-    //     self.final_eval(&ctx)
-    // }
 }
 
 // // expr that we can add things

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_lazy.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_lazy.rs
@@ -64,26 +64,21 @@ impl LazyFieldType {
         }
     }
 
-    // todo reuse for world func
     fn for_world(&self, idents: StructIdents) -> TokenStream2 {
         let name = idents.name();
         let orig_ty = idents.orig_ty();
         match self.0 {
             ControlType::F32_2 => {
-                // quote! {#name: self.#name.eval_lazy(ctx)?}
                 quote! { #name: glam::vec2(self.#name[0].eval_lazy(ctx)? as f32, self.#name[1].eval_lazy(ctx)? as f32)}
             }
             ControlType::F32_3 => {
                 quote! {#name: glam::vec3(self.#name[0].eval_lazy(ctx)? as f32, self.#name[1].eval_lazy(ctx)? as f32, self.#name[2].eval_lazy(ctx)? as f32)}
-                // quote! {#name: self.#name.eval_lazy(ctx)?}
             }
             ControlType::Color => {
                 quote! {#name: murrelet_common::MurreletColor::hsva(self.#name[0].eval_lazy(ctx)? as f32, self.#name[1].eval_lazy(ctx)? as f32, self.#name[2].eval_lazy(ctx)? as f32, self.#name[3].eval_lazy(ctx)? as f32)}
-                // quote! {#name: self.#name.eval_lazy(ctx)?}
             }
-            // ControlType::LinSrgbaUnclamped => quote!{#name: murrelet_livecode::livecode::ControlF32::hsva_unclamped(&self.#name, w)},
             ControlType::Bool => quote! {#name: self.#name.eval_lazy(ctx)? > 0.0},
-            // _ => quote!{#name: self.#name.eval_lazy(ctx)? as #orig_ty}
+            ControlType::LazyNodeF32 => quote! {#name: self.#name.add_more_defs(ctx)? },
             _ => {
                 // for number-like things, we also enable clamping! (it's a bit experimental though, be careful)
                 let f32_out = match (idents.data.f32min, idents.data.f32max) {


### PR DESCRIPTION
structs that contained a LazyControlF32 were failing to macro expansion. I need to rethink a few things but this compiles at least (how should lazy things that contain other lazy things work... I'm going to label it as undefined behavior for now, because I'm not sure how it should work, and seems like it could be a good use case like if you expand a struct in one area of rust code and then want to expand a different variable later.) anywayssss