### PR TITLE
Various changes (first half of October)

### DIFF
--- a/examples/foolish_guillemot/src/lib.rs
+++ b/examples/foolish_guillemot/src/lib.rs
@@ -24,7 +24,7 @@ use wasm_bindgen::prelude::*;
 //     }
 // }
 
-#[derive(Debug, Clone, Default, Livecode)]
+#[derive(Debug, Clone, Livecode, Default)]
 struct StyledShape {
     shape: MurreletCompass,
     style: StyleConf,
@@ -42,7 +42,7 @@ impl StyledShape {
     }
 }
 
-#[derive(Debug, Clone, Default, Livecode)]
+#[derive(Debug, Clone, Livecode, Default)]
 struct SimpleTile(Vec<StyledShape>);
 impl SimpleTile {
     fn draw(&self, draw_ctx: &WebSDrawCtxUnitCell) {

--- a/examples/foolish_guillemot/src/lib.rs
+++ b/examples/foolish_guillemot/src/lib.rs
@@ -24,7 +24,7 @@ use wasm_bindgen::prelude::*;
 //     }
 // }
 
-#[derive(Debug, Clone, Livecode, Default)]
+#[derive(Debug, Clone, Default, Livecode)]
 struct StyledShape {
     shape: MurreletCompass,
     style: StyleConf,
@@ -42,7 +42,7 @@ impl StyledShape {
     }
 }
 
-#[derive(Debug, Clone, Livecode, Default)]
+#[derive(Debug, Clone, Default, Livecode)]
 struct SimpleTile(Vec<StyledShape>);
 impl SimpleTile {
     fn draw(&self, draw_ctx: &WebSDrawCtxUnitCell) {

--- a/murrelet_common/src/geometry.rs
+++ b/murrelet_common/src/geometry.rs
@@ -50,6 +50,18 @@ impl AnglePi {
 
         AnglePi(angle)
     }
+
+    pub fn is_neg(&self) -> bool {
+        self.0 < 0.0
+    }
+}
+
+impl std::ops::Neg for AnglePi {
+    type Output = AnglePi;
+
+    fn neg(self) -> Self::Output {
+        AnglePi(-self.0)
+    }
 }
 
 impl<A> std::ops::Add<A> for Angle

--- a/murrelet_draw/src/compass.rs
+++ b/murrelet_draw/src/compass.rs
@@ -317,3 +317,13 @@ impl MurreletCompass {
         CurveDrawer::new(builder.results(), self.closed)
     }
 }
+
+impl Default for MurreletCompass {
+    fn default() -> Self {
+        Self {
+            start: CurveStart::new(Vec2::default(), AnglePi::new(0.0)),
+            dirs: Default::default(),
+            closed: Default::default(),
+        }
+    }
+}

--- a/murrelet_draw/src/compass.rs
+++ b/murrelet_draw/src/compass.rs
@@ -3,17 +3,23 @@ use glam::Vec2;
 use murrelet_common::*;
 use murrelet_livecode_derive::Livecode;
 
-use crate::curve_drawer::{CurveArc, CurveDrawer, CurvePoints, CurveSegment};
+use crate::{
+    curve_drawer::{CurveArc, CurveDrawer, CurvePoints, CurveSegment},
+    livecodetypes::anglepi::*,
+};
 
-#[derive(Debug, Clone, Copy, Livecode, Default)]
+#[derive(Debug, Clone, Copy, Livecode)]
 pub struct CurveStart {
     loc: Vec2,
-    angle: f32,
+    angle_pi: LivecodeAnglePi,
 }
 
 impl CurveStart {
-    pub fn new(loc: Vec2, angle: f32) -> Self {
-        Self { loc, angle }
+    pub fn new<A: IsAngle>(loc: Vec2, angle: A) -> Self {
+        Self {
+            loc,
+            angle_pi: LivecodeAnglePi::new(angle),
+        }
     }
 }
 
@@ -21,19 +27,29 @@ fn empty_string() -> String {
     String::new()
 }
 
-#[derive(Debug, Clone, Livecode, Default)]
+#[derive(Debug, Clone, Livecode)]
 pub struct CompassDir {
-    angle: f32,
+    angle_pi: LivecodeAnglePi,
     #[livecode(serde_default = "false")]
     is_absolute: bool,
     #[livecode(serde_default = "murrelet_livecode::livecode::empty_string")]
     label: String,
 }
 
-#[derive(Debug, Clone, Livecode, Default)]
+impl CompassDir {
+    pub fn new<A: IsAngle>(angle: A, is_absolute: bool, label: String) -> Self {
+        Self {
+            angle_pi: LivecodeAnglePi::new(angle),
+            is_absolute,
+            label,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Livecode)]
 pub struct CompassArc {
     radius: f32,
-    arc_length: f32,
+    arc_length: LivecodeAnglePi,
     #[livecode(serde_default = "false")]
     is_absolute: bool,
     #[livecode(serde_default = "murrelet_livecode::livecode::empty_string")]
@@ -44,14 +60,14 @@ pub struct CompassArc {
 //     pub fn new(radius: f32, arc_length: f32, is_absolute: bool) -> Self { Self { radius, arc_length, is_absolute } }
 // }
 
-#[derive(Debug, Clone, Livecode, Default)]
+#[derive(Debug, Clone, Livecode)]
 pub struct CompassLine {
     length: f32, // how far should we head in the current direction
     #[livecode(serde_default = "murrelet_livecode::livecode::empty_string")]
     label: String,
 }
 
-#[derive(Debug, Clone, Livecode, Default)]
+#[derive(Debug, Clone, Livecode)]
 pub struct CompassRepeat {
     times: usize,
     what: Vec<CompassAction>,
@@ -66,30 +82,35 @@ pub enum CompassAction {
 }
 
 impl CompassAction {
-    pub fn qangle(angle: f32) -> CompassAction {
-        CompassAction::angle(angle, false, "".to_string())
+    pub fn qangle<A: IsAngle>(angle_pi: A) -> CompassAction {
+        CompassAction::angle(angle_pi, false, "".to_string())
     }
 
     pub fn qarc<A: IsAngle>(radius: f32, arc_length: A) -> CompassAction {
-        CompassAction::arc(radius, arc_length.angle_pi(), false, "".to_string())
+        CompassAction::arc(radius, arc_length, false, "".to_string())
     }
 
     pub fn qline(length: f32) -> CompassAction {
         CompassAction::line(length, "".to_string())
     }
 
-    pub fn angle(angle: f32, is_absolute: bool, label: String) -> CompassAction {
+    pub fn angle<A: IsAngle>(angle_pi: A, is_absolute: bool, label: String) -> CompassAction {
         CompassAction::Angle(CompassDir {
-            angle,
+            angle_pi: LivecodeAnglePi::new(angle_pi),
             is_absolute,
             label,
         })
     }
 
-    pub fn arc(radius: f32, arc_length: f32, is_absolute: bool, label: String) -> CompassAction {
+    pub fn arc<A: IsAngle>(
+        radius: f32,
+        arc_length_pi: A,
+        is_absolute: bool,
+        label: String,
+    ) -> CompassAction {
         CompassAction::Arc(CompassArc {
             radius,
-            arc_length,
+            arc_length: LivecodeAnglePi::new(arc_length_pi),
             is_absolute,
             label,
         })
@@ -106,7 +127,7 @@ impl CompassAction {
 impl Default for CompassAction {
     fn default() -> Self {
         CompassAction::Angle(CompassDir {
-            angle: 0.0,
+            angle_pi: LivecodeAnglePi::ZERO,
             is_absolute: false,
             label: String::new(),
         })
@@ -116,7 +137,7 @@ impl Default for CompassAction {
 pub struct InteractiveCompassBuilder {
     pen_down: bool, // if we've drawn one
     curr_loc: Vec2,
-    curr_angle: f32,
+    curr_angle: AnglePi,
     so_far: Vec<CurveSegment>,
 }
 
@@ -125,18 +146,18 @@ impl InteractiveCompassBuilder {
         Self {
             pen_down: false,
             curr_loc: Vec2::ZERO,
-            curr_angle: 0.0,
+            curr_angle: AnglePi::new(0.0),
             so_far: Vec::new(),
         }
     }
 
-    pub fn add_curve_start_simple(&mut self, loc: Vec2, angle: f32) {
+    pub fn add_curve_start_simple<A: IsAngle>(&mut self, loc: Vec2, angle: A) {
         self.set_curr_angle(angle);
         self.set_curr_loc(loc);
     }
 
     pub fn add_curve_start(&mut self, start: CurveStart) {
-        self.add_curve_start_simple(start.loc, start.angle);
+        self.add_curve_start_simple(start.loc, start.angle_pi);
     }
 
     pub fn new_segments(&mut self, dir: &CompassAction) -> Vec<CurveSegment> {
@@ -171,16 +192,16 @@ impl InteractiveCompassBuilder {
 
     fn set_angle(&mut self, dir: &CompassDir) {
         if dir.is_absolute {
-            self.curr_angle = dir.angle;
+            self.curr_angle = dir.angle_pi.as_angle_pi();
         } else {
-            self.curr_angle += dir.angle;
+            self.curr_angle = self.curr_angle + dir.angle_pi.as_angle_pi();
         }
     }
 
     fn to_basic(&self) -> CurveStart {
         CurveStart {
             loc: self.curr_loc,
-            angle: self.curr_angle,
+            angle_pi: LivecodeAnglePi::new(self.curr_angle),
         }
     }
 
@@ -203,39 +224,45 @@ impl InteractiveCompassBuilder {
         CurveSegment::Points(CurvePoints::new(points))
     }
 
-    fn use_angle_and_length(&self, angle: f32, length: f32) -> Vec2 {
-        AnglePi::new(angle).to_norm_dir() * length
+    fn use_angle_and_length<A: IsAngle>(&self, angle: A, length: f32) -> Vec2 {
+        angle.as_angle_pi().to_norm_dir() * length
     }
 
     fn add_arc(&mut self, x: &CompassArc) -> CurveSegment {
-        let (arc_length, radius) = if x.arc_length < 0.0 {
-            (-x.arc_length, -x.radius)
+        let angle_pi = x.arc_length.as_angle_pi();
+        let (arc_length, radius) = if angle_pi.is_neg() {
+            (-angle_pi, -x.radius)
         } else {
-            (x.arc_length, x.radius)
+            (angle_pi, x.radius)
         };
 
         // starting at our current location, move at a right angle to our current angle
         // negative goes to the left of the line
-        let loc = self.curr_loc + self.use_angle_and_length(self.curr_angle + 0.5, radius);
+        let loc =
+            self.curr_loc + self.use_angle_and_length(self.curr_angle + AnglePi::new(0.5), radius);
 
         // if radius is negative, go backwards
         // end_angle is what we'll update curr angle to, it's always assuming positive radius
         let (start, end, next_angle) = if radius < 0.0 {
             let next_angle = self.curr_angle - arc_length;
             (
-                1.0 + self.curr_angle - 0.5,
-                1.0 + next_angle - 0.5,
+                AnglePi::new(1.0) + self.curr_angle - AnglePi::new(0.5),
+                AnglePi::new(1.0) + next_angle - AnglePi::new(0.5),
                 next_angle,
             )
         } else {
             let next_angle = self.curr_angle + arc_length;
-            (self.curr_angle - 0.5, next_angle - 0.5, next_angle)
+            (
+                self.curr_angle - AnglePi::new(0.5),
+                next_angle - AnglePi::new(0.5),
+                next_angle,
+            )
         };
 
         let a = CurveArc::new(loc, radius.abs(), start, end);
 
         self.curr_loc = a.last_point();
-        self.curr_angle = next_angle % 2.0;
+        self.curr_angle = AnglePi::new(next_angle.angle_pi() % 2.0);
         self.pen_down = true;
 
         CurveSegment::Arc(a)
@@ -250,19 +277,19 @@ impl InteractiveCompassBuilder {
     }
 
     pub fn curr_angle(&self) -> f32 {
-        self.curr_angle
+        self.curr_angle.angle_pi()
     }
 
     pub fn set_curr_loc(&mut self, curr_loc: Vec2) {
         self.curr_loc = curr_loc;
     }
 
-    pub fn set_curr_angle(&mut self, curr_angle: f32) {
-        self.curr_angle = curr_angle;
+    pub fn set_curr_angle<A: IsAngle>(&mut self, curr_angle: A) {
+        self.curr_angle = curr_angle.as_angle_pi();
     }
 }
 
-#[derive(Debug, Clone, Livecode, Default)]
+#[derive(Debug, Clone, Livecode)]
 pub struct MurreletCompass {
     start: CurveStart,
     dirs: Vec<CompassAction>,

--- a/murrelet_draw/src/curve_drawer.rs
+++ b/murrelet_draw/src/curve_drawer.rs
@@ -4,7 +4,9 @@ use glam::*;
 use murrelet_common::{Angle, AnglePi, Circle, IsAngle, IsLength};
 use murrelet_livecode_derive::*;
 
-#[derive(Debug, Clone, Default, Livecode)]
+use crate::livecodetypes::anglepi::*;
+
+#[derive(Debug, Clone, Livecode)]
 pub struct CurveDrawer {
     segments: Vec<CurveSegment>,
     closed: bool, // this is mostly used for algorithms that use curve drawers. you'll need to use a style that's closed
@@ -38,7 +40,7 @@ impl CurveDrawer {
         CurveDrawer::new(
             vec![
                 CurveSegment::new_simple_point(loc),
-                CurveSegment::Arc(CurveArc::new(loc, radius, start.angle_pi(), end.angle_pi())),
+                CurveSegment::Arc(CurveArc::new(loc, radius, start, end)),
             ],
             true,
         )
@@ -98,16 +100,16 @@ impl CurveSegment {
         start: A1,
         end: A2,
     ) -> Self {
-        CurveSegment::Arc(CurveArc::new(
-            loc,
-            radius.len(),
-            start.angle_pi(),
-            end.angle_pi(),
-        ))
+        CurveSegment::Arc(CurveArc::new(loc, radius.len(), start, end))
     }
 
     pub fn new_simple_circle(loc: Vec2, radius: f32) -> Self {
-        CurveSegment::Arc(CurveArc::new(loc, radius, 0.0, 2.0))
+        CurveSegment::Arc(CurveArc::new(
+            loc,
+            radius,
+            AnglePi::new(0.0),
+            AnglePi::new(2.0),
+        ))
     }
 
     pub fn new_simple_point(point: Vec2) -> Self {
@@ -130,56 +132,59 @@ impl CurveSegment {
     }
 }
 
-#[derive(Debug, Clone, Livecode, Default)]
+#[derive(Debug, Clone, Livecode)]
 pub struct CurveArc {
     #[livecode(serde_default = "zeros")]
     pub loc: Vec2, // center of circle
     pub radius: f32,
-    pub start_pi: f32,
-    pub end_pi: f32,
+    pub start_pi: LivecodeAnglePi,
+    pub end_pi: LivecodeAnglePi,
 }
 impl CurveArc {
-    pub fn new(loc: Vec2, radius: f32, start_pi: f32, end_pi: f32) -> Self {
+    pub fn new<A1: IsAngle, A2: IsAngle>(loc: Vec2, radius: f32, start_pi: A1, end_pi: A2) -> Self {
         Self {
             loc,
             radius,
-            start_pi,
-            end_pi,
+            start_pi: LivecodeAnglePi::new(start_pi),
+            end_pi: LivecodeAnglePi::new(end_pi),
         }
     }
 
     pub fn is_in_arc(&self, angle: AnglePi) -> bool {
-        if (self.end_pi - self.start_pi).abs() >= 2.0 {
+        let start_pi = self.start_pi.angle_pi();
+        let end_pi = self.end_pi.angle_pi();
+
+        if (end_pi - start_pi).abs() >= 2.0 {
             true
         } else {
             // eh, try to align it
             let angle_pi = angle.angle_pi();
 
             if self.is_ccw() {
-                angle_pi <= self.end_pi && angle_pi >= self.start_pi
+                angle_pi <= end_pi && angle_pi >= start_pi
             } else {
-                angle_pi <= self.start_pi && angle_pi >= self.end_pi
+                angle_pi <= start_pi && angle_pi >= end_pi
             }
         }
     }
 
     pub fn is_ccw(&self) -> bool {
-        self.end_pi > self.start_pi
+        self.end_pi.angle_pi() > self.start_pi.angle_pi()
     }
 
     // useful for svg
     pub fn is_large_arc(&self) -> bool {
-        (self.end_pi - self.start_pi).abs() > 1.0
+        (self.end_pi.angle_pi() - self.start_pi.angle_pi()).abs() > 1.0
     }
 
     pub fn last_point(&self) -> Vec2 {
-        let curr_angle = self.end_pi * PI;
+        let curr_angle = self.end_pi.angle();
         let (loc_sin, loc_cos) = curr_angle.sin_cos();
         vec2(loc_cos, loc_sin) * self.radius + self.loc
     }
 
     pub fn first_point(&self) -> Vec2 {
-        let curr_angle = self.start_pi * PI;
+        let curr_angle = self.start_pi.angle();
         let (loc_sin, loc_cos) = curr_angle.sin_cos();
         vec2(loc_cos, loc_sin) * self.radius + self.loc
     }
@@ -194,11 +199,13 @@ impl CurveArc {
     }
 
     fn end_angle(&self) -> Angle {
-        AnglePi::new(self.end_pi).into()
+        self.end_pi.as_angle()
+        // AnglePi::new(self.end_pi).into()
     }
 
     fn start_angle(&self) -> Angle {
-        AnglePi::new(self.start_pi).into()
+        self.start_pi.as_angle()
+        // AnglePi::new(self.start_pi).into()
     }
 
     pub fn start_tangent_angle(&self) -> Angle {
@@ -210,7 +217,7 @@ impl CurveArc {
     }
 }
 
-#[derive(Debug, Clone, Livecode, Default)]
+#[derive(Debug, Clone, Livecode)]
 pub struct CurvePoints {
     pub points: Vec<Vec2>,
 }

--- a/murrelet_draw/src/curve_drawer.rs
+++ b/murrelet_draw/src/curve_drawer.rs
@@ -1,5 +1,3 @@
-use std::f32::consts::PI;
-
 use glam::*;
 use murrelet_common::{Angle, AnglePi, Circle, IsAngle, IsLength};
 use murrelet_livecode_derive::*;

--- a/murrelet_draw/src/draw.rs
+++ b/murrelet_draw/src/draw.rs
@@ -387,6 +387,14 @@ impl CoreSDrawCtxUnitCell {
         core.sdraw.svg_style.color = core.sdraw.svg_style.color.with_alpha(alpha);
         core
     }
+
+    pub fn add_unit_cell_keep_this_expr(&self, other: &UnitCellContext) -> Self {
+        Self {
+            unit_cell: self.unit_cell().combine(other),
+            unit_cell_skew: self.unit_cell_skew(),
+            sdraw: self.sdraw.clone(),
+        }
+    }
 }
 
 // just packages things up so it's easier to use

--- a/murrelet_draw/src/lib.rs
+++ b/murrelet_draw/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod compass;
 pub mod curve_drawer;
 pub mod draw;
+pub mod livecodetypes;
 pub mod newtypes;
 pub mod sequencers;
 pub mod style;

--- a/murrelet_draw/src/livecodetypes.rs
+++ b/murrelet_draw/src/livecodetypes.rs
@@ -1,8 +1,7 @@
 // place to put newtypes for livecode
 
 pub mod anglepi {
-    use glam::Vec2;
-    use murrelet_common::{AnglePi, IsAngle};
+    use murrelet_common::{Angle, AnglePi, IsAngle};
     use murrelet_livecode_derive::Livecode;
 
     #[derive(Clone, Copy, Debug, Livecode)]
@@ -18,37 +17,10 @@ pub mod anglepi {
             Self(f.angle_pi())
         }
     }
-    impl IsAngle for LivecodeAnglePi {
-        fn angle_pi(&self) -> f32 {
-            self._to_angle_pi().angle_pi()
-        }
 
-        fn angle(&self) -> f32 {
-            self._to_angle_pi().angle()
-        }
-
-        fn as_angle(&self) -> murrelet_common::Angle {
-            self._to_angle_pi().as_angle()
-        }
-
-        fn as_angle_pi(&self) -> AnglePi {
-            self._to_angle_pi().as_angle_pi()
-        }
-
-        fn to_norm_dir(&self) -> Vec2 {
-            self._to_angle_pi().to_norm_dir()
-        }
-
-        fn to_mat3(&self) -> glam::Mat3 {
-            self._to_angle_pi().to_mat3()
-        }
-
-        fn perp_to_left(&self) -> murrelet_common::Angle {
-            self._to_angle_pi().perp_to_left()
-        }
-
-        fn perp_to_right(&self) -> murrelet_common::Angle {
-            self._to_angle_pi().perp_to_right()
+    impl From<LivecodeAnglePi> for Angle {
+        fn from(value: LivecodeAnglePi) -> Self {
+            value._to_angle_pi().as_angle()
         }
     }
 }

--- a/murrelet_draw/src/livecodetypes.rs
+++ b/murrelet_draw/src/livecodetypes.rs
@@ -1,0 +1,54 @@
+// place to put newtypes for livecode
+
+pub mod anglepi {
+    use glam::Vec2;
+    use murrelet_common::{AnglePi, IsAngle};
+    use murrelet_livecode_derive::Livecode;
+
+    #[derive(Clone, Copy, Debug, Livecode)]
+    pub struct LivecodeAnglePi(f32);
+    impl LivecodeAnglePi {
+        pub const ZERO: Self = LivecodeAnglePi(0.0);
+
+        fn _to_angle_pi(&self) -> AnglePi {
+            AnglePi::new(self.0)
+        }
+
+        pub fn new<A: IsAngle>(f: A) -> Self {
+            Self(f.angle_pi())
+        }
+    }
+    impl IsAngle for LivecodeAnglePi {
+        fn angle_pi(&self) -> f32 {
+            self._to_angle_pi().angle_pi()
+        }
+
+        fn angle(&self) -> f32 {
+            self._to_angle_pi().angle()
+        }
+
+        fn as_angle(&self) -> murrelet_common::Angle {
+            self._to_angle_pi().as_angle()
+        }
+
+        fn as_angle_pi(&self) -> AnglePi {
+            self._to_angle_pi().as_angle_pi()
+        }
+
+        fn to_norm_dir(&self) -> Vec2 {
+            self._to_angle_pi().to_norm_dir()
+        }
+
+        fn to_mat3(&self) -> glam::Mat3 {
+            self._to_angle_pi().to_mat3()
+        }
+
+        fn perp_to_left(&self) -> murrelet_common::Angle {
+            self._to_angle_pi().perp_to_left()
+        }
+
+        fn perp_to_right(&self) -> murrelet_common::Angle {
+            self._to_angle_pi().perp_to_right()
+        }
+    }
+}

--- a/murrelet_draw/src/style.rs
+++ b/murrelet_draw/src/style.rs
@@ -59,8 +59,8 @@ impl StyledPathSvgFill {
     // for nannou
     pub fn to_points_textured<F: IsPolyline>(&self, raw_points: &F) -> Vec<(Vec2, Vec2)> {
         // so using this to center it
-        let (center, size, angle) = find_center_and_size(raw_points);
-        let transform = self.transform * mat4_from_mat3_transform(Mat3::from_angle(-angle));
+        let (center, size, _angle) = find_center_and_size(raw_points);
+        let transform = self.transform; // * mat4_from_mat3_transform(Mat3::from_angle(-angle));
         let points = raw_points
             .into_iter_vec2()
             .map(|x| {

--- a/murrelet_gpu/src/device_state.rs
+++ b/murrelet_gpu/src/device_state.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use image::{GenericImageView, ImageBuffer};
+use image::GenericImageView;
 
 #[cfg(feature = "nannou")]
 use wgpu_for_nannou as wgpu;

--- a/murrelet_gpu/src/gpu_livecode.rs
+++ b/murrelet_gpu/src/gpu_livecode.rs
@@ -15,8 +15,20 @@ pub struct ControlGraphicsRef {
     graphics: GraphicsRef,
 }
 impl ControlGraphicsRef {
-    pub fn new(control: Box<dyn ControlGraphics>, graphics: GraphicsRef) -> ControlGraphicsRef {
-        ControlGraphicsRef { control, graphics }
+    pub fn new(
+        label: &str,
+        control: Box<dyn ControlGraphics>,
+        graphics: Option<GraphicsRef>,
+    ) -> Option<ControlGraphicsRef> {
+        if let Some(gg) = graphics {
+            Some(ControlGraphicsRef {
+                control,
+                graphics: gg,
+            })
+        } else {
+            println!("missing ref! {:?}", label);
+            None
+        }
     }
 
     pub fn update_graphics(&self, c: &GraphicsWindowConf) {

--- a/murrelet_gpu/src/gpu_macros.rs
+++ b/murrelet_gpu/src/gpu_macros.rs
@@ -876,7 +876,10 @@ impl ImageTexture {
     ) -> Self {
         // load one as dummy to get image
         // let source_dims = wgpu::Texture::from_path(c.window, src_path).unwrap().size();
-        let source_dims = c.dims; // ??
+
+        // hrm, when this was set to width/height, it didn't work, it shrunk the whole thing..
+        // let (_, width, height) = crate::device_state::check_img_size(src_path).unwrap();
+        let source_dims = c.dims; //[width, height]; // c.dims; // ??
         let target_dims = c.dims;
         println!("source: {:?} {:?}", source_dims, target_dims);
 
@@ -885,14 +888,14 @@ impl ImageTexture {
                 raw r###"
                 // the sizes of the input and output maps are in pixels
                 let entire_source_size_pxl = uniforms.more_info_other.xy;
-                let target_size_pxl = uniforms.more_info_other.za;
+                let target_size_pxl = uniforms.more_info_other.zw;
 
                 // let aspect = vec2<f32>(uniforms.dims.x / uniforms.dims.y);
 
-                let source_normalized_dims = vec2<f32>(1.0 / entire_source_size_pxl.x, 1.0 / entire_source_size_pxl.y); //uniforms.dims.za;
+                let source_normalized_dims = vec2<f32>(1.0 / entire_source_size_pxl.x, 1.0 / entire_source_size_pxl.y); //uniforms.dims.zw;
 
                 // grab the intended size of the source window and offset.
-                let windowed_source_size_pxl = uniforms.more_info.za;
+                let windowed_source_size_pxl = uniforms.more_info.zw;
                 let windowed_source_offset_pxl = uniforms.more_info.xy;
 
                 let windowed_source_offset_txl = windowed_source_offset_pxl * source_normalized_dims;
@@ -909,8 +912,8 @@ impl ImageTexture {
                 // now figure out where in the square we should sample, this will just zoom in
                 let target_coords_txl = target_coords_txl1 * window_to_entire_ratio + windowed_source_offset_txl;
 
-                // let result: vec4<f32> = vec4<f32>(target_coords_txl, 0.0, 1.0);
                 let result: vec4<f32> = textureSample(tex, tex_sampler, target_coords_txl);
+
                 "###;
             )
         };

--- a/murrelet_gpu/src/graphics_ref.rs
+++ b/murrelet_gpu/src/graphics_ref.rs
@@ -22,6 +22,9 @@ pub const DEFAULT_TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgb
 #[cfg(feature = "nannou")]
 pub const DEFAULT_TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba16Float;
 
+#[cfg(not(feature = "nannou"))]
+pub const DEFAULT_LOADED_TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+#[cfg(feature = "nannou")]
 pub const DEFAULT_LOADED_TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
 
 fn shader_from_path(device: &wgpu::Device, data: &str) -> wgpu::ShaderModule {
@@ -331,6 +334,13 @@ pub struct GraphicsRef {
 impl GraphicsRef {
     pub fn name(&self) -> String {
         self.graphics.borrow().name.clone()
+    }
+
+    pub fn more_info(&self) -> ([f32; 4], [f32; 4]) {
+        (
+            self.graphics.borrow().uniforms.more_info,
+            self.graphics.borrow().uniforms.more_info_other,
+        )
     }
 
     pub fn new_with_src<'a>(
@@ -784,6 +794,8 @@ impl Graphics {
             &initial_uniform_buffer,
             &sampler,
         );
+
+        println!("bind_group {:?}", bind_group);
 
         Self {
             name,

--- a/murrelet_livecode/src/types.rs
+++ b/murrelet_livecode/src/types.rs
@@ -1,6 +1,8 @@
+use core::fmt;
+
 use evalexpr::{build_operator_tree, EvalexprError, HashMapContext, Node};
 use murrelet_common::IdxInRange;
-use serde::Deserialize;
+use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer};
 
 use crate::{expr::ExprWorldContextValues, livecode::LivecodeFromWorld, state::LivecodeWorldState};
 
@@ -79,15 +81,12 @@ impl<Source> ControlVecElementRepeat<Source> {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "elemty")]
+#[derive(Debug, Clone)]
 pub enum ControlVecElement<Source> {
     Single(Source),
     Repeat(ControlVecElementRepeat<Source>),
 }
 
-// i need to refactor some things now that unitcells and livecode are basically the same.
-// for now just have.. copies :(
 impl<Source> ControlVecElement<Source> {
     pub fn raw(c: Source) -> Self {
         Self::Single(c)
@@ -101,5 +100,41 @@ impl<Source> ControlVecElement<Source> {
             ControlVecElement::Single(c) => Ok(vec![c.o(w)?]),
             ControlVecElement::Repeat(r) => r.eval_and_expand_vec(w),
         }
+    }
+}
+
+// chatgpt
+impl<'de, Source> Deserialize<'de> for ControlVecElement<Source>
+where
+    Source: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = serde_yaml::Value::deserialize(deserializer)?;
+
+        let mut errors = Vec::new();
+
+        // try the simple one
+        match Source::deserialize(value.clone()) {
+            Ok(single) => return Ok(ControlVecElement::Single(single)),
+            Err(e) => errors.push(format!("Single variant failed: {}", e)),
+        }
+
+        //
+        match ControlVecElementRepeat::deserialize(value.clone()) {
+            Ok(repeat) => return Ok(ControlVecElement::Repeat(repeat)),
+            Err(e) => {
+                // it's gonna fail, so just check what
+                errors.push(format!("Repeat variant failed: {}", e))
+            }
+        }
+
+        // Both variants failed, return an error with detailed messages
+        Err(serde::de::Error::custom(format!(
+            "data did not match any variant of ControlVecElement:\n{}",
+            errors.join("\n")
+        )))
     }
 }

--- a/murrelet_livecode/src/types.rs
+++ b/murrelet_livecode/src/types.rs
@@ -1,8 +1,6 @@
-use core::fmt;
-
 use evalexpr::{build_operator_tree, EvalexprError, HashMapContext, Node};
 use murrelet_common::IdxInRange;
-use serde::{de::Visitor, ser::SerializeStruct, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer};
 
 use crate::{expr::ExprWorldContextValues, livecode::LivecodeFromWorld, state::LivecodeWorldState};
 

--- a/murrelet_livecode/src/unitcells.rs
+++ b/murrelet_livecode/src/unitcells.rs
@@ -614,7 +614,7 @@ impl UnitCellExprWorldContext {
 
     pub fn from_idx1d(idx: IdxInRange) -> UnitCellExprWorldContext {
         UnitCellExprWorldContext {
-            x: idx.pct() + idx.half_step_pct(),
+            x: idx.pct(),
             y: 0.0,
             z: 0.0,
             x_i: idx.i(),
@@ -630,8 +630,8 @@ impl UnitCellExprWorldContext {
 
     pub fn from_idx2d(idx: IdxInRange2d, h_ratio: f32) -> UnitCellExprWorldContext {
         UnitCellExprWorldContext {
-            x: idx.i.pct() + idx.i.half_step_pct(),
-            y: idx.j.pct() + idx.j.half_step_pct(),
+            x: idx.i.pct(),
+            y: idx.j.pct(),
             z: 0.0,
             x_i: idx.i.i(),
             y_i: idx.j.i(),
@@ -654,9 +654,9 @@ impl UnitCellExprWorldContext {
             + x_idx.i();
 
         UnitCellExprWorldContext {
-            x: x_idx.pct() + x_idx.half_step_pct(),
-            y: y_idx.pct() + y_idx.half_step_pct(),
-            z: z_idx.pct() + z_idx.half_step_pct(),
+            x: x_idx.pct(),
+            y: y_idx.pct(),
+            z: z_idx.pct(),
             x_i: x_idx.i(),
             y_i: y_idx.i(),
             z_i: z_idx.i(),

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_lazy.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_lazy.rs
@@ -181,6 +181,7 @@ impl GenFinal for FieldTokensLazy {
         let new_enum_ident = idents.new_ident;
         let name = idents.name;
         let vis = idents.vis;
+        let tags = idents.lazy_enum_tag;
 
         let for_struct = variants.iter().map(|x| x.for_struct.clone());
         let for_world = variants.iter().map(|x| x.for_world.clone());
@@ -188,6 +189,7 @@ impl GenFinal for FieldTokensLazy {
         quote! {
             #[derive(Debug, Clone, Default, murrelet_livecode_derive::LivecodeOnly)]
             #[allow(non_camel_case_types)]
+            #tags
             #vis enum #new_enum_ident {
                 #[default]
                 DefaultNoop,

--- a/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_livecode.rs
+++ b/murrelet_livecode_macros/murrelet_livecode_derive/src/derive_livecode.rs
@@ -337,6 +337,7 @@ impl GenFinal for FieldTokensLivecode {
         }
     }
 
+    // Vec<CurveSegment>, Vec<f32>
     fn from_recurse_struct_vec(idents: StructIdents) -> FieldTokensLivecode {
         let serde = idents.serde();
         let name = idents.name();
@@ -379,13 +380,12 @@ impl GenFinal for FieldTokensLivecode {
             quote! {#serde #name: #new_ty}
         };
 
-        let debug_name = name.to_string();
         let for_world = {
             if how_to_control_internal.needs_to_be_evaluated() {
                 match wrapper {
                     VecDepth::NotAVec => unreachable!("not a vec in a vec?"),
                     VecDepth::Vec => {
-                        quote! {#name: self.#name.iter().map(|x| x.eval_and_expand_vec(w, #debug_name)).collect::<Result<Vec<_>, _>>()?.into_iter().flatten().collect()}
+                        quote! {#name: self.#name.iter().map(|x| x.eval_and_expand_vec(w)).collect::<Result<Vec<_>, _>>()?.into_iter().flatten().collect()}
                     }
                     VecDepth::VecVec => {
                         quote! {
@@ -393,7 +393,7 @@ impl GenFinal for FieldTokensLivecode {
                                 let mut result = Vec::with_capacity(self.#name.len());
                                 for internal_row in &self.#name {
                                     result.push(
-                                        internal_row.iter().map(|x| x.eval_and_expand_vec(w, #debug_name)).collect::<Result<Vec<_>, _>>()?.into_iter().flatten().collect()
+                                        internal_row.iter().map(|x| x.eval_and_expand_vec(w)).collect::<Result<Vec<_>, _>>()?.into_iter().flatten().collect()
                                     )
                                 }
                                 result


### PR DESCRIPTION
Another random collection of changes, which don't really fix many things but ah I need to get the main repo in sync and (as the solo dev), I make the rules around here.

 - chatgpt o1 model could actually help me finally write the deserialization that tells you what failed in the Struct in ControlVecElement<Struct, so no more of this `- c:` nonsense, yayyyy.
 - update compass to use angles, and make a LivecodeAnglePi (a little annoying cuz AnglePi struct is in common, and it didn't make sense to put it in the livecode.rs package with the trait, so create it in draw.
 - update nannou texture to not apply rotation because now I can rotate the texture itself...
 - I think image loading never quite worked, so I tried fixing it. There's still a problem when the loaded texture is larger than the main window texture that I need to fix.
 - I'm sure I had a good reason to add half a pct to 'x' and 'y' in world (probably to center it...), but it means things don't actually go from 0 to 1. So remove that.
 - need to pass through enum_tag='untagged' to the lazy thing.